### PR TITLE
Change astropy to release version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 
 jinja2
 cython
-astropy
+git+https://github.com/astropy/astropy.git@ffc0a89b2c42fd440eb19bcb2f93db90cab3c98b
 git+https://github.com/nmearl/pyqtgraph.git
 -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 
 jinja2
 cython
-git+https://github.com/nmearl/astropy.git
+astropy
 git+https://github.com/nmearl/pyqtgraph.git
 -e .


### PR DESCRIPTION
This changes the requirements.txt file to call for using the release version instead of ``nmearl/astropy``. We can put in a specific version if that's better, but if there was a specific reason why specviz needs the *dev* version of astropy, I can instead modify this to point to ``astropy/astropy`` instead of ``nmearl/astropy``.  Better yet, if we can point to a specific *commit*, that's even better.