### PR TITLE
Added missing entry for linelists in package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ package_info = get_package_info()
 # Add the project-global data
 package_info['package_data'].setdefault(PACKAGENAME, [])
 package_info['package_data'][PACKAGENAME].append('data/*')
+package_info['package_data'][PACKAGENAME].append('data/linelists/*')
 
 # Define entry points for command-line scripts
 entry_points = {'console_scripts': []}


### PR DESCRIPTION
Without this, specviz doesn't work when doing a clean install