### PR TITLE
Fix ConfigParser compatibility with Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,11 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
Fix ConfigParser compatibility with Python 3. Fixes #212 .