### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An gui-based interactive analysis tool for one dimensional astronomical data
 using Python.
 
 For installation instructions, please visit the
-[online documentation](http://specviz.readthedocs.org/).
+[online documentation](https://specviz.readthedocs.io/).
 All documentation can also be found in the `docs` directory of the source.
 
 ## Contributing

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Installation
 
 SpecViz is distributed through the `Anaconda <https://anaconda.org>`_ package
 manager. Specifically, it lives within Space Telescope Science Institute's
-`AstroConda <http://astroconda.readthedocs.io/>`_ channel.
+`AstroConda <https://astroconda.readthedocs.io/>`_ channel.
 
 If you do not have Anaconda, please follow the `instructions here
 <https://www.continuum.io/downloads>`_ to install it, or scroll down for

--- a/docs/source/model_fitting.rst
+++ b/docs/source/model_fitting.rst
@@ -4,7 +4,7 @@ Model Fitting
 =============
 
 SpecViz utilizes
-`Astropy Models and Fitting <http://astropy.readthedocs.org/en/latest/modeling/index.html>`_
+:ref:`Astropy Models and Fitting <astropy:astropy-modeling>`
 to fit models to its spectra. For example, you can fit one model to the
 continuum, another to an emission line of interest, and yet another to an
 absorption line.

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ long_description = SpecViz is a tool for 1-D spectral visualization and analysis
 author = Nicholas Earl, Ivo Busko, Pey Lian Lim
 author_email = nearl@stsci.edu
 license = BSD
-url = http://specviz.readthedocs.org
+url = https://specviz.readthedocs.io
 edit_on_github = False
 github_project = spacetelescope/specviz
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ DESCRIPTION = metadata.get('description', 'An interactive astronomical analysis 
 AUTHOR = metadata.get('author', 'Nicholas Earl, Ivo Busko, Pey Lian Lim')
 AUTHOR_EMAIL = metadata.get('author_email', 'nearl@stsci.edu')
 LICENSE = metadata.get('license', 'unknown')
-URL = metadata.get('url', 'http://specviz.readthedocs.org')
+URL = metadata.get('url', 'https://specviz.readthedocs.io')
 
 # Get the long description from the package's docstring
 __import__(PACKAGENAME)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.