### PR TITLE
replace GaussianAbsorption1D with GaussianAbsorption

### DIFF
--- a/specviz/analysis/models/gaussian_absorption.py
+++ b/specviz/analysis/models/gaussian_absorption.py
@@ -1,0 +1,32 @@
+from astropy.modeling import Fittable1DModel, models
+from astropy.modeling.parameters import Parameter
+
+__all__ = ['GaussianAbsorption']
+
+
+class GaussianAbsorption(Fittable1DModel):
+    """
+    The Gaussian absorption profile.
+
+    This is defined in terms of the emission Gaussian1D model.
+
+    """
+    amplitude = Parameter(default=1., min=0.)
+    mean = Parameter(default=1.)
+    stddev = Parameter(default=1.)
+
+    @staticmethod
+    def evaluate(x, amplitude, mean, stddev):
+        """
+        GaussianAbsorption model function.
+        """
+        return models.Gaussian1D.evaluate(x, -amplitude, mean, stddev)
+
+    @staticmethod
+    def fit_deriv(x, amplitude, mean, stddev):
+        """
+        GaussianAbsorption model function derivatives.
+        """
+        import operator
+        return list(map(operator.neg, models.Gaussian1D.fit_deriv(x, -amplitude, mean, stddev)))
+

--- a/specviz/interfaces/factories.py
+++ b/specviz/interfaces/factories.py
@@ -10,6 +10,7 @@ import logging
 # LOCAL
 from ..analysis.models.spline import Spline1D
 from ..analysis.models.blackbody import BlackBody
+from ..analysis.models.gaussian_absorption import GaussianAbsorption
 
 # THIRD-PARTY
 from astropy.modeling import models, fitting
@@ -48,7 +49,7 @@ class ModelFactory(Factory):
     """
     all_models = {
         'Gaussian': models.Gaussian1D,
-        'GaussianAbsorption': models.GaussianAbsorption1D,
+        'GaussianAbsorption': GaussianAbsorption,
         'Lorentz': models.Lorentz1D,
         'MexicanHat': models.MexicanHat1D,
         'Trapezoid': models.Trapezoid1D,

--- a/specviz/interfaces/initializers.py
+++ b/specviz/interfaces/initializers.py
@@ -219,7 +219,9 @@ def _setattr(instance, mname, pname, value):
         The value to assign.
     """
     try:
-        setattr(instance, _p_names[mname][pname], value)
+        # conflicts happen when we try to set a parameter value
+        # as a Quantity. Use the raw value instead.
+        setattr(instance, _p_names[mname][pname], value.value)
     except KeyError:
         pass
 
@@ -237,7 +239,7 @@ _initializers = {
     'LogParabola1D':              _WideBand1DInitializer,
     'Box1D':                      _Width_LineProfile1DInitializer,
     'Gaussian1D':                 _Sigma_LineProfile1DInitializer,
-    'GaussianAbsorption1D':       _Sigma_LineProfile1DInitializer,
+    'GaussianAbsorption':         _Sigma_LineProfile1DInitializer,
     'Lorentz1D':                  _Width_LineProfile1DInitializer,
     'Voigt1D':                    _Width_LineProfile1DInitializer,
     'MexicanHat1D':               _Sigma_LineProfile1DInitializer,
@@ -251,7 +253,7 @@ _initializers = {
 # This maps the standard names used in the code to the actual names used by astropy.
 _p_names = {
     'Gaussian1D':                 {AMPLITUDE:'amplitude',  POSITION:'mean', WIDTH:'stddev'},
-    'GaussianAbsorption1D':       {AMPLITUDE:'amplitude',  POSITION:'mean', WIDTH:'stddev'},
+    'GaussianAbsorption':         {AMPLITUDE:'amplitude',  POSITION:'mean', WIDTH:'stddev'},
     'Lorentz1D':                  {AMPLITUDE:'amplitude',  POSITION:'x_0',  WIDTH:'fwhm'},
     'Voigt1D':                    {AMPLITUDE:'amplitude_L',POSITION:'x_0',  WIDTH:'fwhm_G'},
     'Box1D':                      {AMPLITUDE:'amplitude',  POSITION:'x_0',  WIDTH:'width'},


### PR DESCRIPTION
This fixes the problem of disappearing absorption lines when fitting. Uses a better definition for an absorption line. The definition in astropy seems questionable.

This is an example of a fit using the new model:

![absorption](https://cloud.githubusercontent.com/assets/3577145/24108134/1ee75d16-0d63-11e7-8df5-2d5ccb361c84.jpg)