### PR TITLE
Fix compatibility with glue 0.10.x

### DIFF
--- a/specviz/app.py
+++ b/specviz/app.py
@@ -86,12 +86,22 @@ def sigint_handler(*args):
 
 
 def glue_setup():
+
     try:
-        from .external.glue.data_viewer import SpecVizViewer
-        from glue.config import qt_client
-        qt_client.add(SpecVizViewer)
+        import glue  # noqa
     except ImportError:
         logging.warning("Failed to import SpecVizViewer; Glue installation not found.")
+        return
+
+    # Check that the version of glue is recent enough
+    from distutils.version import LooseVersion
+    from glue import __version__
+    if LooseVersion(__version__) < LooseVersion('0.10.2'):
+        raise Exception("glue 0.10.2 or later is required for the specviz plugin")
+
+    from .external.glue.data_viewer import SpecVizViewer
+    from glue.config import qt_client
+    qt_client.add(SpecVizViewer)
 
 
 if __name__ == '__main__':

--- a/specviz/external/glue/__init__.py
+++ b/specviz/external/glue/__init__.py
@@ -1,5 +1,0 @@
-def setup():
-    from .data_viewer import SpecVizViewer, MOSVizViewer
-    from glue.config import qt_client
-    qt_client.add(SpecVizViewer)
-    qt_client.add(MOSVizViewer)

--- a/specviz/external/glue/data_viewer.py
+++ b/specviz/external/glue/data_viewer.py
@@ -149,11 +149,11 @@ class SpecVizViewer(BaseVizViewer):
 
         if isinstance(self._layer_widget.layer, Subset):
             subset = self._layer_widget.layer
-            cid = subset.data.id[self._options_widget.file_att[0]]
+            cid = subset.data.id[self._options_widget.file_att]
             mask = subset.to_mask(None)
             component = subset.data.get_component(cid)
         else:
-            cid = self._layer_widget.layer.id[self._options_widget.file_att[0]]
+            cid = self._layer_widget.layer.id[self._options_widget.file_att]
             mask = None
             component = self._layer_widget.layer.get_component(cid)
 

--- a/specviz/external/glue/viewer_options.py
+++ b/specviz/external/glue/viewer_options.py
@@ -35,4 +35,3 @@ class OptionsWidget(QWidget):
             self.file_helper.append_data(data.data)
         else:
             self.file_helper.append_data(data)
-        print(self.file_att)


### PR DESCRIPTION
Note that this will require glue-core 0.10.2 to be released, which I'll try and do this evening (in the mean time this requires the developer version of glue).

One thing that is weird is that if I open a table with 3 entries, when adding the dataset to the specviz viewer, ``on_file_read`` is called three times, but then only one spectrum appears in the data collection in specviz.