### PR TITLE
Temporarily hide the black body model

### DIFF
--- a/specviz/analysis/models/blackbody.py
+++ b/specviz/analysis/models/blackbody.py
@@ -11,7 +11,9 @@ __all__ = ['BlackBody']
 
 class BlackBody(Fittable1DModel):
     """
-    Produce a blackbody flux spectrum
+    Produce a blackbody flux spectrum.
+
+    Note that the wave and flux arrays used to Quantity
 
     Notes
     -----
@@ -27,7 +29,7 @@ class BlackBody(Fittable1DModel):
 
     def evaluate(self, x, temp, norm):
         """
-        Evaluate the blackbody for a given temperature over a wavalength range
+        Evaluate the blackbody for a given temperature over a wavelength range.
 
         Parameters
         ----------
@@ -73,10 +75,10 @@ class BlackBodyInitializer(object):
         instance: BlackBody
             The `BlackBody` model
 
-        wave: numpy.ndarray
+        wave: Quantity
             The wavelength range.
 
-        flux: numpy.ndarray
+        flux: Quantity
             The source flux to normalize to.
         """
         instance.wave = wave

--- a/specviz/interfaces/factories.py
+++ b/specviz/interfaces/factories.py
@@ -65,7 +65,7 @@ class ModelFactory(Factory):
         'Voigt': models.Voigt1D,
         'Box1D': models.Box1D,
         'Spline': Spline1D,
-        'BlackBody': BlackBody,
+        # 'BlackBody': BlackBody,
 
         # polynomials have to be handled separately. Their calling sequence
         # is incompatible with the Fittable1DModel interface, and they run


### PR DESCRIPTION
This is a temporary change for the upcoming Fool's release. Will be reverted when the code that calls the black body initializer and evaluate methods gets fixed.