### PR TITLE
Fix Astropy dev errors on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - ASTROPY_VERSION=stable
+        - SETUP_XVFB=true
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES='sphinx==1.4.8 sphinx_automodapi sphinx_rtd_theme'
         # For this package-template, we include examples of Cython modules,

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ show-response = 1
 [tool:pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
-doctest_plus = disabled
 
 [ah_bootstrap]
 auto_use = True

--- a/specviz/conftest.py
+++ b/specviz/conftest.py
@@ -4,6 +4,19 @@
 
 from astropy.tests.pytest_plugins import *
 
+# Since pytest might execute some tests that use Qt without having
+# started a QApplication instance, we start QApplication here and
+# keep a global reference for the duration of the testing
+
+app, qapp = None, None
+
+def pytest_configure(config):
+    global app, qapp
+    from .app import setup
+    app, qapp = setup()
+    from astropy.tests.pytest_plugins import pytest_configure
+    return pytest_configure(config)
+
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
 # enable_deprecations_as_exceptions()


### PR DESCRIPTION
This attempts to fix the failures with Astropy dev, which actually have nothing to do with Astropy dev itself but more the fact that Astropy no longer bundles pytest, and we are therefore using the latest version of pytest.

Note that ``doctest_plus = disabled`` doesn't have the intended effect, which I've reported in https://github.com/astropy/astropy/issues/6268