### PR TITLE
Fix loading of HDUs with no name

### DIFF
--- a/specviz/utils/parse_fits.py
+++ b/specviz/utils/parse_fits.py
@@ -24,7 +24,7 @@ def parse_fits(filename):
 
     with fits.open(filename) as hdulist:
 
-        for hdu in hdulist:
+        for ihdu, hdu in enumerate(hdulist):
 
             parsed_hdu = {}
 
@@ -74,7 +74,8 @@ def parse_fits(filename):
                                                'unit': unit}
 
             if len(parsed_hdu) > 0:
-                parsed_hdus[hdu.name] = parsed_hdu
+                hdu_name = hdu.name or 'HDU {0}'.format(ihdu)
+                parsed_hdus[hdu_name] = parsed_hdu
 
     return parsed_hdus
 


### PR DESCRIPTION
This fixes the issue with ``generic_spectra.fits`` which was to do with the fact that HDU 1 had no name (which is fine).

@nmearl @kassin - the ``generic_spectra.fits`` file also contains pseudo-WCS in HDU 0, but this is incomplete:

```
CUNIT1  = 'Angstrom'                                                            
CRVAL1  =                200.0                                                  
CDELT1  =                  1.0                                                  
```

specifically, CTYPE1 is missing, so astropy WCS doesn't recognize this as being a spectral WCS. Is this a fake spectrum file, or was it found in the wild?