### PR TITLE
Updates astropy helpers and fixes widget import

### DIFF
--- a/specviz/plugins/layer_list_plugin.py
+++ b/specviz/plugins/layer_list_plugin.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy.units import spectral_density, spectral
 from qtpy import compat
 from qtpy.uic import loadUi
-from qtpy.QtWidgets import QTreeWidgetItem
+from qtpy.QtWidgets import QTreeWidgetItem, QColorDialog
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QPixmap, QIcon
 


### PR DESCRIPTION
An issue with astropy helpers was leading to a dreaded error message `ImportError: parent 'specviz' not in sys.modules` when attempting to use `pip` to install SpecViz, this update solves that. Also, attempting to use the color changer would crash SpecViz due to the widget not having been imported.