### PR TITLE
Improve wizard with disparate detector chips data structures

### DIFF
--- a/specviz/utils/parse_fits.py
+++ b/specviz/utils/parse_fits.py
@@ -69,7 +69,11 @@ def parse_fits(filename):
 
                     data = hdu.data[column.name]
 
-                    parsed_hdu[column.name] = {'data': data,
+                    # If the parsed data is of type string, ignore this column
+                    if isinstance(data, np.chararray):
+                        continue
+
+                    parsed_hdu[column.name] = {'data': data.flatten(),
                                                'ndim': data.ndim,
                                                'shape': data.shape,
                                                'unit': unit,


### PR DESCRIPTION
This covers a corner case (e.g. with COS spectrum files from the MAST archive) wherein the fits arrays are cut up into two parts, each covering one of the two separate detectors.

This follows the mold of the custom loader where the data arrays are flattened.