### PR TITLE
Properly disable menubar when using specviz in glue plugin mode

### DIFF
--- a/specviz/app.py
+++ b/specviz/app.py
@@ -40,7 +40,7 @@ except ModuleNotFoundError:
 
 
 class App(object):
-    def __init__(self, hidden=None, disabled=None):
+    def __init__(self, hidden=None, disabled=None, menubar=True):
         hidden = hidden or {}
         disabled = disabled or {}
 
@@ -49,11 +49,12 @@ class App(object):
         # Instantiate main window object
         self._all_tool_bars = {}
 
-        self.main_window = MainWindow()
-        self.menu_docks = QMenu("Plugins")
-        self.main_window.menu_bar.addMenu(self.menu_docks)
-
-        self.menu_docks.addSeparator()
+        self.main_window = MainWindow(menubar=menubar)
+        if self.main_window.menu_bar is not None:
+            self.menu_docks = self.main_window.menu_bar.addMenu('Plugins')
+            self.menu_docks.addSeparator()
+        else:
+            self.menu_docks = None
 
         # self.main_window.setDockNestingEnabled(True)
 
@@ -100,8 +101,8 @@ class App(object):
                     inst_plgn.hide()
 
                 # Add this dock's visibility action to the menu bar
-                self.menu_docks.addAction(
-                    inst_plgn.toggleViewAction())
+                if self.menu_docks is not None:
+                    self.menu_docks.addAction(inst_plgn.toggleViewAction())
 
         # Sort actions based on priority
         all_actions = [y for x in self._instanced_plugins.values()

--- a/specviz/data/qt/ui/main_window.ui
+++ b/specviz/data/qt/ui/main_window.ui
@@ -57,34 +57,6 @@
     </item>
    </layout>
   </widget>
-  <widget class="QMenuBar" name="menu_bar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>1044</width>
-     <height>22</height>
-    </rect>
-   </property>
-   <widget class="QMenu" name="menu_file">
-    <property name="title">
-     <string>File</string>
-    </property>
-   </widget>
-   <widget class="QMenu" name="menu_edit">
-    <property name="title">
-     <string>Edit</string>
-    </property>
-   </widget>
-   <widget class="QMenu" name="menu_plugins">
-    <property name="title">
-     <string>Plugins</string>
-    </property>
-   </widget>
-   <addaction name="menu_file"/>
-   <addaction name="menu_edit"/>
-   <addaction name="menu_plugins"/>
-  </widget>
   <widget class="QStatusBar" name="status_bar"/>
   <widget class="QToolBar" name="tool_bar">
    <property name="windowTitle">

--- a/specviz/third_party/glue/data_viewer.py
+++ b/specviz/third_party/glue/data_viewer.py
@@ -60,10 +60,8 @@ class SpecVizViewer(DataViewer):
                                   'Statistics': True,
                                   'Model Fitting': True,
                                   'Mask Editor': True,
-                                  'Data List': True})
-
-        # Remove the menubar so that it does not interfere with Glue's
-        self.viewer.main_window.menu_bar = None
+                                  'Data List': True},
+                          menubar=False)
 
         # Remove Glue's viewer status bar
         self.statusBar().hide()

--- a/specviz/widgets/windows.py
+++ b/specviz/widgets/windows.py
@@ -12,12 +12,17 @@ from ..widgets.utils import UI_PATH
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, parent=None, *args, **kwargs):
+    def __init__(self, parent=None, menubar=True, *args, **kwargs):
         super(MainWindow, self).__init__(parent)
 
         dispatch.setup(self)
 
         loadUi(os.path.join(UI_PATH, "main_window.ui"), self)
+
+        if menubar:
+            self.menu_bar = self.menuBar()
+        else:
+            self.menu_bar = None
 
         self.mdi_area.subWindowActivated.connect(self._set_activated_window)
 


### PR DESCRIPTION
At the moment, when using specviz as part of cubeviz, specviz's menu overrides glue's menu (this doesn't happen when using specviz as a standalone plugin in glue). The only clean way to avoid this is to add an option to not construct the menubar in the first place rather than trying to remove it after creation.