### PR TITLE
Fix param locking behavior

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ url = https://specviz.readthedocs.io
 edit_on_github = True
 github_project = spacetelescope/specviz
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 0.4.3
+version = 0.4.4
 install_requires = six pyyaml numpy scipy astropy specutils==0.2.2 pyqtgraph qtpy py_expression_eval docopt
 
 [entry_points]

--- a/specviz/core/data.py
+++ b/specviz/core/data.py
@@ -79,8 +79,6 @@ class Spectrum1DRefLayer(Spectrum1DRef):
             uncertainty = StdDevUncertainty(np.zeros(data.shape))
         elif isinstance(uncertainty, UnknownUncertainty):
             uncertainty = StdDevUncertainty(uncertainty.array)
-        else:
-            print("Creating uncertainty of type: ", uncertainty.__class__)
 
         if mask is None:
             mask = np.zeros(data.shape).astype(bool)

--- a/specviz/data/qt/ui/model_fitting_plugin.ui
+++ b/specviz/data/qt/ui/model_fitting_plugin.ui
@@ -104,10 +104,19 @@ QCheckBox::indicator:unchecked:pressed {
 }</string>
         </property>
         <property name="columnCount">
-         <number>2</number>
+         <number>3</number>
         </property>
+        <attribute name="headerVisible">
+         <bool>true</bool>
+        </attribute>
         <attribute name="headerDefaultSectionSize">
-         <number>150</number>
+         <number>100</number>
+        </attribute>
+        <attribute name="headerMinimumSectionSize">
+         <number>50</number>
+        </attribute>
+        <attribute name="headerStretchLastSection">
+         <bool>false</bool>
         </attribute>
         <column>
          <property name="text">
@@ -117,6 +126,11 @@ QCheckBox::indicator:unchecked:pressed {
         <column>
          <property name="text">
           <string>Value</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>State</string>
          </property>
         </column>
        </widget>

--- a/specviz/plugins/model_fitting_plugin.py
+++ b/specviz/plugins/model_fitting_plugin.py
@@ -250,6 +250,7 @@ class ModelFittingPlugin(Plugin):
             for i, para in enumerate(model.param_names):
                 new_para_item = QTreeWidgetItem(new_item)
                 new_para_item.setText(0, para)
+                new_para_item.setData(0, Qt.UserRole, para)
                 new_para_item.setData(1, Qt.UserRole, model.parameters[i])
                 new_para_item.setText(1, "{:g}".format(model.parameters[i]))
                 new_para_item.setFlags(new_para_item.flags() |

--- a/specviz/plugins/model_fitting_plugin.py
+++ b/specviz/plugins/model_fitting_plugin.py
@@ -43,6 +43,8 @@ class ModelFittingPlugin(Plugin):
         self.fit_model_thread.result.connect(
             lambda layer: dispatch.on_update_model.emit(layer=layer))
 
+        self.contents.tree_widget_current_models.setColumnWidth(2, 50)
+
     def setup_ui(self):
         loadUi(os.path.join(UI_PATH, "model_fitting_plugin.ui"), self.contents)
 
@@ -254,7 +256,7 @@ class ModelFittingPlugin(Plugin):
                                        Qt.ItemIsEditable |
                                        Qt.ItemIsUserCheckable)
 
-                new_para_item.setCheckState(0, Qt.Checked if model.fixed.get(para)
+                new_para_item.setCheckState(2, Qt.Checked if model.fixed.get(para)
                                                           else Qt.Unchecked)
 
             self.contents.tree_widget_current_models.addTopLevelItem(new_item)
@@ -403,7 +405,7 @@ class ModelFittingPlugin(Plugin):
 
                 model_names = [model.name
                                for model in layer.model._submodels]
-                print(expr, model_names)
+
                 expr = expr.format(*model_names)
             # If it's just a single model
             else:
@@ -471,7 +473,7 @@ class ModelFittingPlugin(Plugin):
         self.add_model_item(layer)
 
     def _model_parameter_validation(self, model_item, col=1):
-        if col == 0:
+        if col == 2:
             return
 
         try:
@@ -486,7 +488,8 @@ class ModelFittingPlugin(Plugin):
 
     def _fix_model_parameter(self, model_item, col=0):
         parent = model_item.parent()
-        if parent is not None:
+
+        if col == 2 and parent is not None:
             model = parent.data(0, Qt.UserRole)
             param = getattr(model, model_item.text(0))
             param.fixed = bool(model_item.checkState(col))


### PR DESCRIPTION
The previous locking behavior has columns shared between name and check state; separate them, so the icon represents only when checkable column is clicked.