### PR TITLE
Detect home directory in a portable way

### DIFF
--- a/specviz/plugins/model_fitting_plugin.py
+++ b/specviz/plugins/model_fitting_plugin.py
@@ -23,7 +23,7 @@ from ..widgets.plugin import Plugin
 from ..widgets.utils import UI_PATH
 
 # To memorize last visited directory.
-_model_directory = os.environ["HOME"]
+_model_directory = os.path.expanduser('~')
 
 
 class ModelFittingPlugin(Plugin):


### PR DESCRIPTION
This change fixes an installation error on Windows (`HOME` is not generally defined).

See full log output here:
https://ci.appveyor.com/project/spacetelescope/cubeviz/build/1.0.58/job/827djd5wbuvgqls8

Log snippet:
```python
    Running setup.py install for specviz: finished with status 'error'
    Complete output from command C:\conda\envs\test\python.exe -u -c "import setuptools, tokenize;__file__='C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\pip-build-cmocdxzw\\specviz\\setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record C:\Users\appveyor\AppData\Local\Temp\1\pip-dd3p7ngu-record\install-record.txt --single-version-externally-managed --compile:
    INFO:root:Added APOGEE apVisit to loader registry.
    INFO:root:Added APOGEE apStar to loader registry.
    INFO:root:Added APOGEE aspcapStar to loader registry.
    INFO:root:Added Simple Fits to loader registry.
    INFO:root:Added HST/COS to loader registry.
    INFO:root:Added HST/STIS to loader registry.
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-cmocdxzw\specviz\setup.py", line 84, in <module>
        get_debug_option(PACKAGENAME))
      File "c:\users\appveyor\appdata\local\temp\1\pip-build-cmocdxzw\specviz\astropy_helpers\astropy_helpers\setup_helpers.py", line 117, in get_debug_option
        fromlist=['debug'])[0]
      File "c:\users\appveyor\appdata\local\temp\1\pip-build-cmocdxzw\specviz\astropy_helpers\astropy_helpers\version_helpers.py", line 299, in get_pkg_version_module
        mod = __import__(packagename + '.version', fromlist=fromlist)
      File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-cmocdxzw\specviz\specviz\__init__.py", line 25, in <module>
        from .plugins import *
      File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-cmocdxzw\specviz\specviz\plugins\__init__.py", line 5, in <module>
        from .model_fitting_plugin import ModelFittingPlugin
      File "C:\Users\appveyor\AppData\Local\Temp\1\pip-build-cmocdxzw\specviz\specviz\plugins\model_fitting_plugin.py", line 26, in <module>
        _model_directory = os.environ["HOME"]
      File "C:\conda\envs\test\lib\os.py", line 725, in __getitem__
        raise KeyError(key) from None
    KeyError: 'HOME'
```
