### PR TITLE
Fix to show position update

### DIFF
--- a/specviz/widgets/sub_windows.py
+++ b/specviz/widgets/sub_windows.py
@@ -194,7 +194,7 @@ class PlotSubWindow(UiPlotSubWindow):
             mouse_point = vb.mapSceneToView(pos)
             index = int(mouse_point.x())
 
-            if index > 0 and index < vb.viewRange()[0][1]:
+            if index >= 0 and index < vb.viewRange()[0][1]:
                 self.line_edit_cursor_pos.setText("Pos: {0:4.4g}, "
                                                   "{1:4.4g}".format(
                     mouse_point.x(), mouse_point.y())


### PR DESCRIPTION
The 'Pos:' was not being updated on the bottom toolbar when the mouse is moved around the screen. It appears to have just been a conditional check as the `index` value is == 0 in the normal case.  This fix works in the third_party glue attachment in cubeviz.

![image](https://user-images.githubusercontent.com/18348847/36113818-15d41ede-0ffc-11e8-9530-30f2f8a93255.png)
