### PR TITLE
Create PlotDataItem in item_from_id if it doesn't already exist

### DIFF
--- a/specviz/core/models.py
+++ b/specviz/core/models.py
@@ -118,8 +118,11 @@ class PlotProxyModel(QSortFilterProxyModel):
 
     def item_from_id(self, identifier):
         data_item = self.sourceModel().item_from_id(identifier)
-        item = self._items.get(data_item.identifier)
 
+        if data_item.identifier not in self._items:
+            self._items[data_item.identifier] = PlotDataItem(data_item)
+
+        item = self._items.get(data_item.identifier)
         return item
 
     def data(self, index, role=Qt.DisplayRole):


### PR DESCRIPTION
In ``PlotProxyModel.item_from_index``, ``PlotDataItem``s get created if needed - this extends the same logic to ``PlotProxyModel.item_from_id``. I'm not 100% sure if this is correct, so opening this as a standalone PR to make sure it's not buried in some other changes.