### PR TITLE
Update MANIFEST.in and setup.py to install tracked files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include ah_bootstrap.py
 include setup.cfg
 include specviz/tests/coveragerc
 
-recursive-include specviz *.pyx *.c *.pxd
+recursive-include specviz *.pyx *.c *.pxd 
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *
@@ -31,7 +31,6 @@ include astropy_helpers/ah_bootstrap.py
 
 recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h *.rst
 recursive-include astropy_helpers/astropy_helpers.egg-info *
-# include the sphinx stuff with "*" because there are css/html/rst/etc.
 recursive-include astropy_helpers/astropy_helpers/sphinx *
 
 prune astropy_helpers/build
@@ -39,3 +38,11 @@ prune astropy_helpers/astropy_helpers/tests
 
 
 global-exclude *.pyc *.o
+
+# added by check_manifest.py
+include *.in
+include *.txt
+include *.yml
+recursive-include specviz *.list
+recursive-include specviz *.ui
+recursive-include specviz *.yaml

--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,7 @@ setup(name=PACKAGENAME,
       zip_safe=False,
       use_2to3=False,
       entry_points=entry_points,
+      include_package_data=True,
       python_requires='>={}'.format(__minimum_python_version__),
       **package_info
       )


### PR DESCRIPTION
I had a problem installing from the git master because it doesn't install the UI files.  This PR updates setup.py and MANIFEST.in to fix the issue. Check the extra lines at the bottom of the MANIFEST.in file to make sure you really want them - I went ahead and ran `check-manifest` just to see what was left out.

Minimally, `recursive-include specviz *.ui` and adding `install_package_data=True` to the setup are needed, but I'm not sure about the others. 

If this PR is in error, feel free to close!