### PR TITLE
Fix spelling of embedded in API

### DIFF
--- a/specviz/app.py
+++ b/specviz/app.py
@@ -27,7 +27,7 @@ class Application(QApplication):
     current_workspace_changed = Signal(QMainWindow)
     workspace_added = Signal(Workspace)
 
-    def __init__(self, *args, file_path=None, file_loader=None, embeded=False,
+    def __init__(self, *args, file_path=None, file_loader=None, embedded=False,
                  dev=False, skip_splash=False, **kwargs):
         super(Application, self).__init__(*args, **kwargs)
 
@@ -44,7 +44,7 @@ class Application(QApplication):
 
         # If specviz is not being embded in another application, go ahead and
         # perform the normal gui setup procedure.
-        if not embeded:
+        if not embedded:
             # Cache a reference to the currently active window
             self.current_workspace = self.add_workspace()
 
@@ -52,7 +52,7 @@ class Application(QApplication):
             self.current_workspace.add_plot_window()
 
             # Set embed mode state
-            self.current_workspace.set_embeded(embeded)
+            self.current_workspace.set_embedded(embedded)
 
         if dev:
             from astropy.modeling.models import Gaussian1D
@@ -180,7 +180,7 @@ def start(version=False, file_path=None, loader=None, embed=None, dev=None, hide
 
     # Start the application, passing in arguments
     app = Application(sys.argv, file_path=file_path, file_loader=loader,
-                      embeded=embed, dev=dev, skip_splash=hide_splash)
+                      embedded=embed, dev=dev, skip_splash=hide_splash)
 
     # Enable hidpi icons
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)

--- a/specviz/third_party/glue/viewer.py
+++ b/specviz/third_party/glue/viewer.py
@@ -190,7 +190,7 @@ class SpecvizDataViewer(DataViewer):
 
         # Fake a current_workspace property so that plugins can mount
         self.specviz_window = Workspace()
-        self.specviz_window.set_embeded(True)
+        self.specviz_window.set_embedded(True)
         QApplication.instance().current_workspace = self.specviz_window
 
         # Add an intially empty plot window

--- a/specviz/widgets/workspace.py
+++ b/specviz/widgets/workspace.py
@@ -220,10 +220,10 @@ class Workspace(QMainWindow):
                     sub_window.plot_widget.getAxis('bottom').setPen('w')
                     sub_window.plot_widget.getAxis('left').setPen('w')
 
-    def set_embeded(self, embed):
+    def set_embedded(self, embed):
         """
         Toggles the visibility of certain parts of the ui to make it more
-        amenable to being embeded in other applications.
+        amenable to being embedded in other applications.
         """
         if embed:
             self.menu_bar.hide()


### PR DESCRIPTION
This is fairly minor issue, but since it's part of the API, it should probably be fixed.

Also, since it is part of the API, I'm not sure whether we need to maintain some kind of backwards compatibility here.