### PR TITLE
Fix for SpectralRegion stats calculation

### DIFF
--- a/specviz/plugins/statistics/statistics_widget.py
+++ b/specviz/plugins/statistics/statistics_widget.py
@@ -40,12 +40,13 @@ def clip_region(spectrum, region):
             region.upper < spectrum.spectral_axis.min():
         return None
 
-    # Clip region:
-    if region.lower < spectrum.spectral_axis.min():
-        region.lower = spectrum.spectral_axis.min()
-    if region.upper > spectrum.spectral_axis.max():
-        region.upper = spectrum.spectral_axis.max()
-    return region
+    # Clip region. There is currently no way to update
+    # SpectralRegion lower and upper so we have to create
+    # a new object here.
+    lower = max(region.lower, spectrum.spectral_axis.min())
+    upper = min(region.upper, spectrum.spectral_axis.max())
+
+    return SpectralRegion(lower, upper)
 
 
 def compute_stats(spectrum):


### PR DESCRIPTION
There was an error in the code when updating the lower or upper bound of a SpectralRegion. This is not possible in the new code.  The code was re-factored to create a new SpectralRegion object instead. Works locally.

Fixes https://github.com/spacetelescope/specviz/issues/467