### PR TITLE
Reworked the default region size

### DIFF
--- a/specviz/widgets/plotting.py
+++ b/specviz/widgets/plotting.py
@@ -483,10 +483,11 @@ class PlotWidget(pg.PlotWidget):
         disp_axis = self.getAxis('bottom')
         mid_point = disp_axis.range[0] + (disp_axis.range[1] -
                                           disp_axis.range[0]) * 0.5
+        disp_range = disp_axis.range[1] - disp_axis.range[0]
 
         region = LinearRegionItem(
-            values=(min_bound or (disp_axis.range[0] + mid_point * 0.75),
-                    max_bound or (disp_axis.range[1] - mid_point * 0.75)))
+            values=(min_bound or (mid_point - disp_range*0.3),
+                    max_bound or (mid_point + disp_range*0.3)))
 
         def _on_region_updated(new_region):
             # If the most recently selected region is already the currently


### PR DESCRIPTION
The default region size was not being calculated quite right. I re-worked the calculation and now the default region size fits within the displayed region.

E.g., 
![image](https://user-images.githubusercontent.com/18348847/47444021-882ae400-d783-11e8-9630-e141f256dd84.png)

![image](https://user-images.githubusercontent.com/18348847/47444086-b6102880-d783-11e8-8cf4-e1319db09f87.png)


Fixes: https://github.com/spacetelescope/specviz/issues/475