### PR TITLE
specify specutils version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ edit_on_github = True
 github_project = spacetelescope/specviz
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy, pyqt5, pyqtgraph, qtawesome, qtpy, specutils, click, pytest, asteval
+install_requires = astropy, pyqt5, pyqtgraph, qtawesome, qtpy, specutils>=0.4, click, pytest, asteval
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.6.dev0
 # Note: you will also need to change this in your package's __init__.py


### PR DESCRIPTION
This should fix #464 - this is actually an "aspirational" requirement because I'm not sure it's currently true... but I know some of the current/near-term PRs will require it.