### PR TITLE
Force users to choose loader before selecting file in dialog

### DIFF
--- a/specviz/widgets/workspace.py
+++ b/specviz/widgets/workspace.py
@@ -316,13 +316,20 @@ class Workspace(QMainWindow):
         :class:`~specutils.Spectrum1D` object and thereafter adds it to the
         data model.
         """
-        filters = [x['Format'] + " (*)"
+        # This ensures that users actively have to select a file type before
+        # being able to select a file. This should make it harder to
+        # accidentally load a file using the wrong type, which results in weird
+        # errors.
+        default_filter = '-- Select file type --'
+
+        filters = [default_filter] + [x['Format'] + " (*)"
                    for x in io_registry.get_formats(Spectrum1D)
                    if x['Read'] == 'Yes']
 
         file_path, fmt = compat.getopenfilename(parent=self,
                                                 caption="Load spectral data file",
-                                                filters=";;".join(filters))
+                                                filters=";;".join(filters),
+                                                selectedfilter=default_filter)
 
         if not file_path:
             return


### PR DESCRIPTION
This is intended to prevent accidental use of wrong file type when using the Load Data dialog.

I realize this goes against what we discussed yesterday, but there are no tests here. This is going to be very difficult to test in an automated test suite since the dialog is actually a canned one from Qt itself, and it runs synchronously in the main thread. This means we couldn't even attempt to access this dialog without running a separate thread within our unit tests and yuck.

