### PR TITLE
added tooltip and removed max width

### DIFF
--- a/specviz/core/items.py
+++ b/specviz/core/items.py
@@ -22,6 +22,7 @@ class DataItem(QStandardItem):
         self.setData(name, self.NameRole)
         self.setData(identifier, self.IdRole)
         self.setData(data, self.DataRole)
+        self.setToolTip(name)
 
         self.setCheckable(True)
 

--- a/specviz/widgets/ui/workspace.ui
+++ b/specviz/widgets/ui/workspace.ui
@@ -53,7 +53,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>250</width>
+         <width>16777215</width>
          <height>16777215</height>
         </size>
        </property>


### PR DESCRIPTION
The maximum width of the list view (where the data color and names show) was set to 250. This was removed (the default is still narrow) so now people can increase the width to see the full data names.

I also added a tooltip based on the name so one can hover on the data name to see what it is if the width is still narrow.

![image](https://user-images.githubusercontent.com/18348847/47654214-b7b16600-db60-11e8-96fe-9b115b476aa6.png)

Fixes https://github.com/spacetelescope/specviz/issues/494