### PR TITLE
WIP: Make default line width 2 pixels

### DIFF
--- a/specviz/core/items.py
+++ b/specviz/core/items.py
@@ -75,7 +75,7 @@ class PlotDataItem(pg.PlotDataItem):
         self._data_unit = self._data_item.flux.unit.to_string()
         self._spectral_axis_unit = self._data_item.spectral_axis.unit.to_string()
         self._color = color or next(flatui)
-        self._width = 1
+        self._width = 2
         self._visible = False
 
         # Include error bar item


### PR DESCRIPTION
The default line width for the spectra is 1 pixel which is quite narrow.  Changed it to 2.

1 pixel width:
![image](https://user-images.githubusercontent.com/18348847/47676486-23acc200-db93-11e8-9fd3-f6043f7d3401.png)

2 pixel width:
![image](https://user-images.githubusercontent.com/18348847/47676498-2ad3d000-db93-11e8-97cd-da56f6b3466d.png)

Talked to @nluetzge and @gderosa2004 and they were good with the increase in default line width.