### PR TITLE
Fix glue plugin tests and functionality

### DIFF
--- a/specviz/third_party/glue/tests/test_utils.py
+++ b/specviz/third_party/glue/tests/test_utils.py
@@ -14,8 +14,7 @@ from glue.core.coordinates import WCSCoordinates
 from ..utils import glue_data_has_spectral_axis, glue_data_to_spectrum1d
 
 
-@pytest.mark.xfail(run=False, reason="at this point, unknown reason")
-def test_conversion_utils():
+def test_conversion_utils_1d():
 
     # Set up simple spectral WCS
     wcs = WCS(naxis=1)

--- a/specviz/third_party/glue/tests/test_viewer.py
+++ b/specviz/third_party/glue/tests/test_viewer.py
@@ -13,7 +13,6 @@ from glue.core.coordinates import WCSCoordinates
 from ..viewer import SpecvizDataViewer
 
 
-@pytest.mark.xfail(run=False, reason="at this point, unknown reason")
 class TestSpecvizDataViewer(object):
 
     def setup_method(self, method):

--- a/specviz/third_party/glue/utils.py
+++ b/specviz/third_party/glue/utils.py
@@ -5,7 +5,7 @@ from specutils import Spectrum1D
 from glue.core.subset import Subset
 from glue.core.coordinates import WCSCoordinates
 
-__all__ = ['is_glue_data_1d_spectrum', 'glue_data_to_spectrum1d']
+__all__ = ['glue_data_has_spectral_axis', 'glue_data_to_spectrum1d']
 
 
 def glue_data_has_spectral_axis(data):
@@ -17,8 +17,12 @@ def glue_data_has_spectral_axis(data):
     data : `glue.core.data.Data`
         The data to check
     """
+
     if isinstance(data, Subset):
         data = data.data
+
+    if not isinstance(data.coords, WCSCoordinates):
+        return False
 
     spec_axis = data.coords.wcs.naxis - 1 - data.coords.wcs.wcs.spec
 
@@ -67,6 +71,6 @@ def glue_data_to_spectrum1d(data_or_subset, attribute, statistic='mean'):
     else:
         values = values * u.Unit(component.units)
 
-    spec1d = Spectrum1D(values, wcs=data.coords.wcs)
+    wcs_spec = data.coords.wcs.sub([WCSSUB_SPECTRAL])
 
-    return spec1d
+    return Spectrum1D(values, wcs=wcs_spec)


### PR DESCRIPTION
For reasons I don't fully understand, the construction of Spectrum1D in the glue plugin was changed in https://github.com/spacetelescope/specviz/pull/456. However, this doesn't work properly because of a bug in specutils (https://github.com/astropy/specutils/issues/369).

This PR re-instates the old way of doing this, and also fixes ``glue_data_has_spectral_axis`` for glue Data objects that don't have WCS coordinates.