### PR TITLE
[WIP] Store reference to plugin in tool bar actions

### DIFF
--- a/specviz/core/plugin.py
+++ b/specviz/core/plugin.py
@@ -56,13 +56,6 @@ class DecoratorRegistry:
 
 
 class Plugin(DecoratorRegistry):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self._plugin_bar_decorator = PluginBarDecorator()
-        self._tool_bar_decorator = ToolBarDecorator()
-        self._plot_bar_decorator = PlotBarDecorator()
-
     @property
     def registry(self):
         return self._registry
@@ -89,6 +82,8 @@ class Plugin(DecoratorRegistry):
                 for meth_name, meth in members:
                     if hasattr(meth, 'wrapped') and (filt is None or meth.plugin_type == filt):
                         meth(workspace)
+
+                return plugin
 
             self._registry.append(cls_wrapper)
 
@@ -162,10 +157,6 @@ class Plugin(DecoratorRegistry):
                 action = QAction(parent)
                 action.setText(name)
 
-                # Store a reference to the plugin in the ui-added action
-                # TODO: come up with better solution...
-                action.plugin = plugin
-
                 if icon is not None:
                     action.setIcon(icon)
 
@@ -198,10 +189,6 @@ class Plugin(DecoratorRegistry):
                 parent = workspace.current_plot_window.tool_bar
                 action = QAction(parent)
 
-                # Store a reference to the plugin in the ui-added action
-                # TODO: come up with better solution...
-                action.plugin = plugin
-
                 action.setText(name)
 
                 if icon is not None:
@@ -217,104 +204,6 @@ class Plugin(DecoratorRegistry):
                 action.triggered.connect(lambda: func(plugin, *args, **kwargs))
 
             # self.registry.append(func_wrapper)
-
-            return func_wrapper
-        return plot_bar_decorator
-
-
-class PluginBarDecorator(DecoratorRegistry):
-    def __call__(self, name, icon):
-        logging.info("Adding plugin '%s'.", name)
-
-        def plugin_bar_decorator(cls):
-            cls.wrapped = True
-            cls.type = 'plugin'
-
-            @wraps(cls)
-            def cls_wrapper(workspace, *args, **kwargs):
-                if workspace is None:
-                    return
-
-                cls.hub = Hub(workspace)
-                plugin = cls()
-
-                if workspace is not None:
-                    workspace.plugin_tab_widget.addTab(
-                        plugin, icon, name)
-
-                # Call any internal tool or plot bar decorators
-                members = inspect.getmembers(plugin, predicate=inspect.ismethod)
-                [meth(workspace) for meth_name, meth in members if hasattr(meth, 'wrapped')]
-
-            self.registry.append(cls_wrapper)
-
-            return cls_wrapper
-        return plugin_bar_decorator
-
-
-class ToolBarDecorator(DecoratorRegistry):
-    def __call__(self, name, icon=None, location=None):
-        def tool_bar_decorator(func):
-            func.wrapped = True
-            func.plugin_type = 'tool'
-
-            @wraps(func)
-            def func_wrapper(plugin, workspace, *args, **kwargs):
-                if workspace is None:
-                    return
-
-                parent = workspace.main_tool_bar
-                action = QAction(parent)
-                action.setText(name)
-
-                if icon is not None:
-                    action.setIcon(icon)
-
-                if location is not None:
-                    for level in location.split('/'):
-                        parent = self.get_action(parent, level)
-
-                parent.addAction(action)
-                action.triggered.connect(lambda: func(plugin, *args, **kwargs))
-
-            self.registry.append(func_wrapper)
-
-            return func_wrapper
-        return tool_bar_decorator
-
-
-class PlotBarDecorator(DecoratorRegistry):
-    def __call__(self, name, icon=None, location=None):
-        def plot_bar_decorator(func):
-            func.wrapped = True
-            func.plugin_type = 'plot'
-
-            @wraps(func)
-            def func_wrapper(plugin, workspace, *args, **kwargs):
-                if workspace is None:
-                    return
-
-                if workspace.current_plot_window is None:
-                    return
-
-                parent = workspace.current_plot_window.tool_bar
-                action = QAction(parent)
-
-                action.setText(name)
-
-                if icon is not None:
-                    action.setIcon(icon)
-
-                if location is not None:
-                    for level in location.split('/'):
-                        parent = self.get_action(parent, level)
-
-                before_action = [x for x in parent.actions()
-                                 if x.isSeparator()].pop()
-                parent.insertAction(before_action, action)
-                action.triggered.connect(lambda: func(plugin, *args, **kwargs))
-
-            self.registry.append(func_wrapper)
 
             return func_wrapper
         return plot_bar_decorator

--- a/specviz/core/plugin.py
+++ b/specviz/core/plugin.py
@@ -162,6 +162,10 @@ class Plugin(DecoratorRegistry):
                 action = QAction(parent)
                 action.setText(name)
 
+                # Store a reference to the plugin in the ui-added action
+                # TODO: come up with better solution...
+                action.plugin = plugin
+
                 if icon is not None:
                     action.setIcon(icon)
 
@@ -193,6 +197,10 @@ class Plugin(DecoratorRegistry):
 
                 parent = workspace.current_plot_window.tool_bar
                 action = QAction(parent)
+
+                # Store a reference to the plugin in the ui-added action
+                # TODO: come up with better solution...
+                action.plugin = plugin
 
                 action.setText(name)
 


### PR DESCRIPTION
This stores a simple reference to a plugin action's parent plugin object class so that it can be accessed via the gui testing functions.