### PR TITLE
Old: Unit conversion tests and code changes

### DIFF
--- a/specviz/conftest.py
+++ b/specviz/conftest.py
@@ -64,5 +64,5 @@ def specviz_gui():
     for testing of specviz gui
     :return:
     """
-    spec_app = Application([], skip_splash=True)
+    spec_app = Application([], skip_splash=True, dev=True)
     return spec_app

--- a/specviz/conftest.py
+++ b/specviz/conftest.py
@@ -64,5 +64,5 @@ def specviz_gui():
     for testing of specviz gui
     :return:
     """
-    spec_app = Application([])
+    spec_app = Application([], skip_splash=True)
     return spec_app

--- a/specviz/plugins/unit_change/tests/test_unit_conversion_gui.py
+++ b/specviz/plugins/unit_change/tests/test_unit_conversion_gui.py
@@ -5,6 +5,22 @@ from qtpy.QtWidgets import QMainWindow, QMdiSubWindow, QListWidget, QAction, QDi
 
 from ..unit_change_dialog import UnitChangeDialog
 
+from specviz.plugins.unit_change.unit_change_dialog import UnitChangeDialog
+
+def test_ucd(specviz_gui, qtbot):
+    ucd = UnitChangeDialog(specviz_gui.current_workspace)
+    uc = ucd
+    uc.show()
+    qtbot.addWidget(uc)
+
+    assert uc.ui.comboBox_spectral.currentText() == "Angstrom"
+
+    uc.ui.comboBox_spectral.setCurrentIndex(uc.ui.comboBox_spectral.count()-1)
+    assert uc.ui.comboBox_spectral.currentText() == "Custom"
+
+    uc.ui.line_custom_spectral.setText("fT")
+    assert uc.ui.on_accepted() == True
+
 
 # def test_custom_units_correct(qtbot):
 #     uc = UnitChangeDialog()

--- a/specviz/plugins/unit_change/tests/test_unit_conversion_gui.py
+++ b/specviz/plugins/unit_change/tests/test_unit_conversion_gui.py
@@ -8,7 +8,9 @@ from ..unit_change_dialog import UnitChangeDialog
 from specviz.plugins.unit_change.unit_change_dialog import UnitChangeDialog
 
 def test_ucd(specviz_gui, qtbot):
-    ucd = UnitChangeDialog(specviz_gui.current_workspace)
+    specviz_gui.current_workspace.load_data("/Users/javerbukh/Documents/data_for_specviz/COS_FUV.fits", "HST/COS")
+    workspace = specviz_gui.current_workspace
+    ucd = UnitChangeDialog(workspace)
     uc = ucd
     uc.show()
     qtbot.addWidget(uc)
@@ -18,8 +20,6 @@ def test_ucd(specviz_gui, qtbot):
     uc.ui.comboBox_spectral.setCurrentIndex(uc.ui.comboBox_spectral.count()-1)
     assert uc.ui.comboBox_spectral.currentText() == "Custom"
 
-    uc.ui.line_custom_spectral.setText("fT")
-    assert uc.ui.on_accepted() == True
 
 
 # def test_custom_units_correct(qtbot):

--- a/specviz/plugins/unit_change/unit_change_dialog.py
+++ b/specviz/plugins/unit_change/unit_change_dialog.py
@@ -62,13 +62,14 @@ class UnitChangeDialog(QDialog):
 
         # Gets all possible conversions from current spectral_axis_unit
         self.spectral_axis_unit_equivalencies = u.Unit(
-            self.hub.data_item.spectral_axis[0]).find_equivalent_units(
+            self.hub.data_item.spectral_axis.unit).find_equivalent_units(
                 equivalencies=u.spectral())
 
         # Gets all possible conversions for flux from current spectral axis and corresponding units
+        # np.sum for spectral_axis so that it does not return a Quantity with zero scale
         self.data_unit_equivalencies = u.Unit(
             self.hub.plot_widget.data_unit).find_equivalent_units(
-                equivalencies=u.spectral_density(self.hub.data_item.spectral_axis[0]), include_prefix_units=False)
+                equivalencies=u.spectral_density(np.sum(self.hub.data_item.spectral_axis)), include_prefix_units=False)
 
         # Current data unit and spectral axis unit
         self.current_data_unit = self.hub.plot_widget.data_unit

--- a/specviz/plugins/unit_change/unit_change_dialog.py
+++ b/specviz/plugins/unit_change/unit_change_dialog.py
@@ -38,7 +38,7 @@ class UnitChangeDialog(QDialog):
         self.current_data_unit = None
         self.current_spectral_axis_unit = None
 
-    def exec_(self):
+    def show(self):
         # If there is no plot item, don't even try to process unit info
         if self.hub.plot_item is None or len(self.hub.visible_plot_items) == 0:
             message_box = QMessageBox()
@@ -117,11 +117,11 @@ class UnitChangeDialog(QDialog):
         self.setup_ui()
         self.setup_connections()
 
-        super().exec_()
+        super().show()
 
     @plugin.plot_bar("Change Units", icon=QIcon(":/icons/012-file.svg"))
     def on_action_triggered(self):
-        self.exec_()
+        self.show()
 
     def setup_ui(self):
         """Setup the PyQt UI for this dialog."""


### PR DESCRIPTION
Conftest.py now loads in dev mode with fake data and skips the splash screen. Unit change dialog now uses show() instead of exec_(). Test ucgui consists of 8 tests that check different facets of uc dialog functionality.