### PR TITLE
Add model saving and loading

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,6 @@ Using SpecViz
 
    getting-started
    unit_conversion
-   model_fitting.rst
    arithmetic-layer
    model_fitting
    stats_sidebar

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Using SpecViz
 
    getting-started
    unit_conversion
+   model_fitting.rst
    arithmetic-layer
    model_fitting
    stats_sidebar

--- a/specviz/conftest.py
+++ b/specviz/conftest.py
@@ -1,5 +1,6 @@
 # This file is used to configure the behavior of pytest when using the Astropy
 # test infrastructure.
+import time
 
 from astropy.version import version as astropy_version
 if astropy_version < '3.0':
@@ -65,4 +66,5 @@ def specviz_gui():
     :return:
     """
     spec_app = Application([], skip_splash=True, dev=True)
-    return spec_app
+    yield spec_app
+    spec_app.quit()

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -260,7 +260,6 @@ class ModelEditor(QWidget):
             # uses the full, un-truncated data value.
             if item.column() == 1:
                 item.setData(float(item.text()), Qt.UserRole + 1)
-                # item.setText("{:.5g}".format(float(item.text()))) # dont change user input
                 item.setText(item.text())
             self._redraw_model()
         else:

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -160,14 +160,12 @@ class ModelEditor(QWidget):
             if self.model_tree_view.model().evaluate() is None:
                 self._on_equation_edit_button_clicked()
 
-    def _save_model(self, filename, model_obj):
+    def _save_models(self, filename):
+        model_editor_model = self.hub.plot_item.data_item.model_editor_model
         with open(filename, 'wb') as handle:
-            pickle.dump(model_obj, handle)
+            pickle.dump(model_editor_model.fittable_models, handle)
 
-    def _on_save_model(self):
-
-        plot_data_item = self.hub.plot_item
-        model_editor_model = plot_data_item.data_item.model_editor_model
+    def _on_save_model(self, interactive=True):
 
         # There are no models to save
         if not model_editor_model.fittable_models:
@@ -183,7 +181,7 @@ class ModelEditor(QWidget):
         if not outfile:
             return
 
-        self._save_model(outfile, model_editor_model.fittable_models)
+        self._save_models(outfile)
 
         self.new_message_box(
             text='Model saved',

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -213,6 +213,8 @@ class ModelEditor(QWidget):
         for i in range(0, 4):
             self.model_tree_view.resizeColumnToContents(i)
 
+        self._redraw_model()
+
     def _add_fittable_model(self, model_type):
         if issubclass(model_type, MODELS['Polynomial1D']):
             text, ok = QInputDialog.getInt(self, 'Polynomial1D',

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -77,6 +77,8 @@ class ModelEditor(QWidget):
         self.advanced_settings_button.clicked.connect(
             lambda: ModelAdvancedSettingsDialog(self, self).exec())
 
+        self.save_model_button.clicked.connect(self._on_save_model)
+
         self.data_selection_combo.setModel(self.hub.model)
 
         # When a plot data item is select, get its model editor model
@@ -149,6 +151,10 @@ class ModelEditor(QWidget):
             # force open the arithmetic editor so the user can fix it.
             if self.model_tree_view.model().evaluate() is None:
                 self._on_equation_edit_button_clicked()
+
+    def _on_save_model(self):
+        self.new_message_box(text='No model available',
+                             info='No model exists to be saved.')
 
     def _add_fittable_model(self, model_type):
         if issubclass(model_type, MODELS['Polynomial1D']):

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -162,11 +162,13 @@ class ModelEditor(QWidget):
 
     def _save_models(self, filename):
         model_editor_model = self.hub.plot_item.data_item.model_editor_model
+        models = model_editor_model.fittable_models
         with open(filename, 'wb') as handle:
             pickle.dump(model_editor_model.fittable_models, handle)
 
     def _on_save_model(self, interactive=True):
 
+        model_editor_model = self.hub.data_item.model_editor_model
         # There are no models to save
         if not model_editor_model.fittable_models:
             self.new_message_box(text='No model available',
@@ -215,18 +217,14 @@ class ModelEditor(QWidget):
         if issubclass(model_type, MODELS['Polynomial1D']):
             text, ok = QInputDialog.getInt(self, 'Polynomial1D',
                                            'Enter Polynomial1D degree:')
-            if ok:
-                # Create a new astropy model class definition with the degree
-                # data already embedded
-                model_type = type(
-                    model_type.__name__, (model_type,),
-                    {'__init__': lambda self, *args, **kwargs:
-                        super(model_type, self).__init__(
-                            degree=int(text), **kwargs)})
-            else:
+            # User decided not to create a model after all
+            if not ok:
                 return
 
-        model = model_type()
+            model = model_type(int(text))
+        else:
+            model = model_type()
+
         self._add_model(model)
 
     def _redraw_model(self):

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -153,8 +153,14 @@ class ModelEditor(QWidget):
                 self._on_equation_edit_button_clicked()
 
     def _on_save_model(self):
-        self.new_message_box(text='No model available',
-                             info='No model exists to be saved.')
+
+        plot_data_item = self.hub.plot_item
+        model_editor_model = plot_data_item.data_item.model_editor_model
+
+        if not model_editor_model.fittable_models:
+            self.new_message_box(text='No model available',
+                                 info='No model exists to be saved.')
+            return
 
     def _add_fittable_model(self, model_type):
         if issubclass(model_type, MODELS['Polynomial1D']):

--- a/specviz/plugins/model_editor/model_editor.ui
+++ b/specviz/plugins/model_editor/model_editor.ui
@@ -6,15 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>262</width>
-    <height>824</height>
+    <width>360</width>
+    <height>818</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -80,7 +89,16 @@
         <property name="spacing">
          <number>0</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -105,7 +123,16 @@
            <property name="spacing">
             <number>0</number>
            </property>
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -173,6 +200,17 @@
              <property name="icon">
               <iconset resource="../../data/resources/resources.qrc">
                <normaloff>:/icons/configuration.svg</normaloff>:/icons/configuration.svg</iconset>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="save_model_button">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="icon">
+              <iconset>
+               <normaloff>../../data/resources/014-save.svg</normaloff>../../data/resources/014-save.svg</iconset>
              </property>
             </widget>
            </item>

--- a/specviz/plugins/model_editor/tests/test_models.py
+++ b/specviz/plugins/model_editor/tests/test_models.py
@@ -84,6 +84,7 @@ def test_save_model(specviz_gui, tmpdir):
 
     model_editor = specviz_gui.current_workspace._plugin_bars['Model Editor']
 
+    # Open the model editor and create a model
     model_editor._on_create_new_model()
     model_editor._add_fittable_model(models.Gaussian1D)
 
@@ -101,3 +102,36 @@ def test_save_model(specviz_gui, tmpdir):
     assert len(saved_models) == 1
     assert 'Gaussian1D' in saved_models
     assert isinstance(saved_models['Gaussian1D'], models.Gaussian1D)
+
+
+def test_load_model(specviz_gui, tmpdir):
+    hub = Hub(workspace=specviz_gui.current_workspace)
+
+    model_editor = specviz_gui.current_workspace._plugin_bars['Model Editor']
+
+    # Open the model editor
+    model_editor._on_create_new_model()
+    model_editor_model = hub.plot_item.data_item.model_editor_model
+
+    # Sanity check to make sure no models exist so far
+    assert len(model_editor_model.fittable_models) == 0
+
+    # Create a pickle on the fly to use for testing
+    model_file = str(tmpdir.join('new_model.smf'))
+    new_models = {
+        'Gaussian1D': models.Gaussian1D(),
+        'Polynomial1D': models.Polynomial1D(degree=4),
+        'Linear1D': models.Linear1D()
+    }
+    with open(model_file, 'wb') as handle:
+        pickle.dump(new_models, handle)
+
+    model_editor._load_model_from_file(model_file)
+    loaded_models = model_editor_model.fittable_models
+    assert len(loaded_models) == len(new_models)
+    assert 'Gaussian1D' in loaded_models
+    assert isinstance(loaded_models['Gaussian1D'], models.Gaussian1D)
+    assert 'Polynomial1D' in loaded_models
+    assert isinstance(loaded_models['Polynomial1D'], models.Polynomial1D)
+    assert 'Linear1D' in loaded_models
+    assert isinstance(loaded_models['Linear1D'], models.Linear1D)

--- a/specviz/plugins/model_editor/tests/test_models.py
+++ b/specviz/plugins/model_editor/tests/test_models.py
@@ -1,3 +1,6 @@
+import os
+import pickle
+
 import numpy as np
 
 from astropy import units as u
@@ -74,3 +77,27 @@ def test_model_fitting(specviz_gui):
     result = model_editor_model.evaluate()
 
     np.testing.assert_allclose(result.parameters, gg_fit.parameters)
+
+
+def test_save_model(specviz_gui, tmpdir):
+    hub = Hub(workspace=specviz_gui.current_workspace)
+
+    model_editor = specviz_gui.current_workspace._plugin_bars['Model Editor']
+
+    model_editor._on_create_new_model()
+    model_editor._add_fittable_model(models.Gaussian1D)
+
+    model_editor_model = hub.plot_item.data_item.model_editor_model
+    assert len(model_editor_model.fittable_models) == 1
+
+    outfile = str(tmpdir.join('model.smf'))
+    model_editor._save_models(outfile)
+
+    assert os.path.exists(outfile)
+
+    with open(outfile, 'rb') as handle:
+        saved_models = pickle.load(handle)
+
+    assert len(saved_models) == 1
+    assert 'Gaussian1D' in saved_models
+    assert isinstance(saved_models['Gaussian1D'], models.Gaussian1D)


### PR DESCRIPTION
Currently this just uses `pickle` for simplicity, but it should be easy to adapt for other output formats.

This resolves #516.

Also, this is based on #543 and will need to be rebased once that is merged.