### PR TITLE
Model fitting improvements

### DIFF
--- a/specviz/plugins/model_editor/models.py
+++ b/specviz/plugins/model_editor/models.py
@@ -1,14 +1,9 @@
-import uuid
+import re
 
 import astropy.units as u
-import numpy as np
-import qtawesome as qta
-from qtpy.QtCore import QSortFilterProxyModel, Qt
-from qtpy.QtGui import QStandardItem, QStandardItemModel
-from specutils import Spectrum1D
-from qtpy.QtGui import QValidator
 from asteval import Interpreter
-from qtpy.QtCore import Signal, Qt
+from qtpy.QtCore import QSortFilterProxyModel, Qt, Signal
+from qtpy.QtGui import QStandardItem, QStandardItemModel, QValidator
 
 
 class ModelFittingModel(QStandardItemModel):
@@ -102,6 +97,27 @@ class ModelFittingModel(QStandardItemModel):
             if len(self._equation) > 0 else "{}".format(model_name)
 
         return model_item.index()
+
+    def remove_model(self, row):
+        """
+        Remove an astropy model from the internal qt data model.
+
+        Parameters
+        ----------
+        row : int
+            The row in the qt model that is to be removed.
+        """
+        # Get the model first so that we can re-parse the equation
+        model_item = self.item(row, 0)
+
+        # Remove the model name from the equation
+        self.equation = re.sub(
+            "(\+|-|\*|\/|=|>|<|>=|<=|&|\||%|!|\^|\(|\))\s+?({})".format(
+                model_item.text()),
+            "", self._equation)
+
+        # Remove the model item from the internal qt model
+        self.removeRow(row)
 
     def reset_equation(self):
         self._equation = ""


### PR DESCRIPTION
Previously, removing a model resulted in an invalid arithmetic equation which would prevent the user from being able to fit the model again until they fixed it. There was no feedback about why clicking the fitting button didn't work properly.

This PR adds some regex to auto-remove the model name from the arithmetic equation and if the new equation is invalid, will force open the arithmetic editor so that the user can fix the equation.