### PR TITLE
Model Editor Checkbox Fix

### DIFF
--- a/specviz/plugins/model_editor/items.py
+++ b/specviz/plugins/model_editor/items.py
@@ -23,6 +23,11 @@ class ModelDataItem(DataItem):
         return self.data(self.DataRole).flux
 
     @property
+    def spectrum(self):
+        flux = self.flux  # Update the flux
+        return super().spectrum
+
+    @property
     def model_editor_model(self):
         return self._model_editor_model
 

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -192,7 +192,8 @@ class ModelEditor(QWidget):
                 spectrum = spectrum.new_flux_unit(plot_data_item.data_unit)
                 plot_data_item.data_item.set_data(spectrum)
 
-        plot_data_item.set_data()
+            # Only draw if ModelDataItem
+            plot_data_item.set_data()
 
     def _on_model_item_changed(self, item):
         if item.parent():
@@ -200,9 +201,10 @@ class ModelEditor(QWidget):
             # value has changed. Note that the internal stored data has not
             # been truncated at all, only the displayed text value. All fitting
             # uses the full, un-truncated data value.
-            item.setData(float(item.text()), Qt.UserRole + 1)
-            # item.setText("{:.5g}".format(float(item.text()))) # dont change user input
-            item.setText(item.text())
+            if item.column() == 1:
+                item.setData(float(item.text()), Qt.UserRole + 1)
+                # item.setText("{:.5g}".format(float(item.text()))) # dont change user input
+                item.setText(item.text())
             self._redraw_model()
         else:
             # In this case, the user has renamed a model. Since the equation

--- a/specviz/plugins/model_editor/models.py
+++ b/specviz/plugins/model_editor/models.py
@@ -77,7 +77,8 @@ class ModelFittingModel(QStandardItemModel):
             param_value.setData(parameter.value, Qt.UserRole + 1)
 
             # Store the unit information
-            param_unit = QStandardItem("{}".format(parameter.unit))
+            # param_unit = QStandardItem("{}".format(parameter.unit))
+            param_unit = QStandardItem("Plot Units")
             param_unit.setData(parameter.unit, Qt.UserRole + 1)
             param_unit.setEditable(False)
 


### PR DESCRIPTION
Model editor's `Fixed` column crashes when the checkbox is clicked. This PR fixes this bug. I also added "Plot Units" to every unit display in the model editor param box. Lastly, I made sure that the model editor redraws a plot only if the selected `plot_data_item` is of type `ModelDataItem`.