### PR TITLE
Fix duplicate operations action in tool bar

### DIFF
--- a/specviz/core/plugin.py
+++ b/specviz/core/plugin.py
@@ -37,22 +37,22 @@ class DecoratorRegistry:
                     button.setMenu(menu)
 
                 return menu
-            else:
-                action = QAction(parent)
-                action.setText(level)
+        else:
+            action = QAction(parent)
+            action.setText(level)
 
-                if isinstance(parent, QToolBar):
-                    parent.addAction(action)
-                    button = parent.widgetForAction(action)
-                    button.setPopupMode(QToolButton.InstantPopup)
-                elif isinstance(parent, QMenu):
-                    parent.addAction(action)
-                    button = action
+            if isinstance(parent, QToolBar):
+                parent.addAction(action)
+                button = parent.widgetForAction(action)
+                button.setPopupMode(QToolButton.InstantPopup)
+            elif isinstance(parent, QMenu):
+                parent.addAction(action)
+                button = action
 
-                menu = QMenu(parent)
-                button.setMenu(menu)
+            menu = QMenu(parent)
+            button.setMenu(menu)
 
-                return menu
+            return menu
 
 
 class Plugin(DecoratorRegistry):


### PR DESCRIPTION
Looks like the action resolver had an accidental indentation in the for loop. Reverting back to fix the duplicate actions in the tool bar.

Fixes #566.