### PR TITLE
Connect Stats to Model and Display Digit Patch

### DIFF
--- a/specviz/plugins/model_editor/model_advanced_settings.ui
+++ b/specviz/plugins/model_editor/model_advanced_settings.ui
@@ -7,42 +7,28 @@
     <x>0</x>
     <y>0</y>
     <width>296</width>
-    <height>187</height>
+    <height>221</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="6" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="1">
-    <widget class="QLineEdit" name="relative_error_line_edit">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="relative_error_label">
-     <property name="text">
-      <string>Relative Error</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="max_iterations_label">
-     <property name="text">
-      <string>Max Iterations</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
     <widget class="QLineEdit" name="max_iterations_line_edit">
      <property name="text">
       <string/>
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -55,7 +41,28 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="1">
+   <item row="4" column="0">
+    <widget class="QLabel" name="epsilon_label">
+     <property name="text">
+      <string>Epsilon</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="relative_error_label">
+     <property name="text">
+      <string>Relative Error</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="max_iterations_label">
+     <property name="text">
+      <string>Max Iterations</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
     <widget class="QLineEdit" name="epsilon_line_edit">
      <property name="text">
       <string/>
@@ -72,17 +79,30 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="epsilon_label">
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="relative_error_line_edit">
      <property name="text">
-      <string>Epsilon</string>
+      <string/>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="1" column="1">
+    <widget class="QSpinBox" name="displayed_digits_spin_box">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>20</number>
+     </property>
+     <property name="value">
+      <number>5</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="displayed_digits_label">
+     <property name="text">
+      <string>Displayed Digits</string>
      </property>
     </widget>
    </item>

--- a/specviz/plugins/model_editor/model_editor.py
+++ b/specviz/plugins/model_editor/model_editor.py
@@ -44,6 +44,7 @@ class ModelEditor(QWidget):
 
         self.fitting_options = {
             'fitter': 'Levenberg-Marquardt',
+            'displayed_digits': 5,
             'max_iterations': optimizers.DEFAULT_MAXITER,
             'relative_error': optimizers.DEFAULT_ACC,
             'epsilon': optimizers.DEFAULT_EPS,
@@ -384,6 +385,7 @@ class ModelEditor(QWidget):
 
         # Load options
         fitter = FITTERS[self.fitting_options["fitter"]]
+        output_formatter = "{:0.%sg}" % self.fitting_options['displayed_digits']
 
         kwargs = {}
         if fitter is fitting.LevMarLSQFitter:
@@ -446,7 +448,7 @@ class ModelEditor(QWidget):
                 else:
                     parameter = getattr(fit_mod, param_name)
 
-                model_item.child(cidx, 1).setText("{:0.5g}".format(parameter.value))
+                model_item.child(cidx, 1).setText(output_formatter.format(parameter.value))
                 model_item.child(cidx, 1).setData(parameter.value, Qt.UserRole + 1)
                 model_item.child(cidx, 3).setData(parameter.fixed, Qt.UserRole + 1)
 
@@ -476,6 +478,7 @@ class ModelAdvancedSettingsDialog(QDialog):
 
         fitting_options = self.model_editor.fitting_options
 
+        self.displayed_digits_spin_box.setValue(fitting_options['displayed_digits'])
         self.max_iterations_line_edit.setText(str(fitting_options['max_iterations']))
         self.relative_error_line_edit.setText(str(fitting_options['relative_error']))
         self.epsilon_line_edit.setText(str(fitting_options['epsilon']))
@@ -532,9 +535,11 @@ class ModelAdvancedSettingsDialog(QDialog):
         max_iterations = int(self.max_iterations_line_edit.text())
         relative_error = float(self.relative_error_line_edit.text())
         epsilon = float(self.epsilon_line_edit.text())
+        displayed_digits = self.displayed_digits_spin_box.value()
 
         self.model_editor.fitting_options = {
             'fitter': fitting_type,
+            'displayed_digits': displayed_digits,
             'max_iterations': max_iterations,
             'relative_error': relative_error,
             'epsilon': epsilon,

--- a/specviz/plugins/statistics/statistics_widget.py
+++ b/specviz/plugins/statistics/statistics_widget.py
@@ -133,6 +133,8 @@ class StatisticsWidget(QWidget):
         self.hub.workspace.current_selected_changed.connect(self.update_statistics)
         # When new plot window is added, connect signals
         self.hub.workspace.plot_window_added.connect(self._connect_plot_window)
+        # When an item in the workspace model changes, update the stat widget
+        self.hub.model.itemChanged.connect(self.update_statistics)
 
         # Connect any currently open plot windows
         for plot_window in self.hub.plot_windows:


### PR DESCRIPTION
This PR introduces the following:
1) Stat widget listens to data changes via `itemChanged` signals.
2) Option to set the number of sig figs as discussed in #558 : 
<img width="332" alt="screen shot 2018-11-19 at 11 45 01 am" src="https://user-images.githubusercontent.com/10345916/48724264-c4bcf480-ebf6-11e8-928b-7b5cb95cf38b.png">
