### PR TITLE
Force checking on all added model items

### DIFF
--- a/specviz/core/items.py
+++ b/specviz/core/items.py
@@ -15,8 +15,7 @@ class DataItem(QStandardItem):
     IdRole = Qt.UserRole + 2
     DataRole = Qt.UserRole + 3
 
-    def __init__(self, name, identifier, data, is_model=False,
-                 *args, **kwargs):
+    def __init__(self, name, identifier, data, *args, **kwargs):
         super(DataItem, self).__init__(*args, **kwargs)
 
         self.setData(name, self.NameRole)
@@ -139,15 +138,13 @@ class PlotDataItem(pg.PlotDataItem):
             self.is_spectral_axis_unit_compatible(spectral_axis_unit)
 
     def is_data_unit_compatible(self, unit):
-        return (self.data_item.flux.unit == "" or
-                unit is not None and
+        return (unit is not None and
                 self.data_item.flux.unit.is_equivalent(
                     unit, equivalencies=spectral_density(
                         self.data_item.spectral_axis)))
 
     def is_spectral_axis_unit_compatible(self, unit):
-        return (self.data_item.spectral_axis.unit == "" or
-                unit is not None and
+        return (unit is not None and
                 self.data_item.spectral_axis.unit.is_equivalent(
                     unit, equivalencies=spectral()))
 

--- a/specviz/plugins/arithmetic/arithmetic_editor.py
+++ b/specviz/plugins/arithmetic/arithmetic_editor.py
@@ -86,6 +86,7 @@ class Arithmetic(QDialog):
         matches = [item.text(0) for item in matches]
         return matches
 
+
 class EquationEditor(QDialog):
     tip_text = ("<b>Note:</b> The spectrum names in the expression should be surrounded "
                 "by {{ }} brackets (e.g. {{{example}}}), and you <br>"
@@ -175,7 +176,8 @@ class EquationEditor(QDialog):
 
         self._equation_editor.set_equation(self.eq_name, self.eq_expression)
 
-        self._equation_editor.hub.workspace.model.add_data(spec=self.evaluated_arith, name=self.eq_name)
+        self._equation_editor.hub.workspace.model.add_data(
+            spec=self.evaluated_arith, name=self.eq_name)
 
         self._close_dialog()
 
@@ -184,7 +186,9 @@ class EquationEditor(QDialog):
 
     def _item_from_name(self, name):
         """Get data item based on name"""
-        return next((x.spectrum for x in self._equation_editor.hub.data_items if x.name == name))
+        return next((x.spectrum for x in self._equation_editor.hub.data_items
+                     if x.name == name))
+
     def _duplicate_component(self, compname):
         if compname in self._equation_editor.find_matches(compname):
             return True
@@ -196,7 +200,8 @@ class EquationEditor(QDialog):
     def _update_status(self):
         """Check status of entered arithmetic"""
         # If the text hasn't changed, no need to check again
-        if hasattr(self, '_cache') and self._cache == (self.text_label.text(), self._get_raw_command()):
+        if hasattr(self, '_cache') and self._cache == (self.text_label.text(),
+                                                       self._get_raw_command()):
             return
 
         if self.text_label.text() == "":
@@ -215,7 +220,8 @@ class EquationEditor(QDialog):
 
         else:
             try:
-                dict_map = {x.name: "self._item_from_name('{}')".format(x.name) for x in self._equation_editor.hub.data_items}
+                dict_map = {x.name: "self._item_from_name('{}')".format(x.name)
+                            for x in self._equation_editor.hub.data_items}
                 raw_str = self._get_raw_command()
                 self.evaluated_arith = eval(raw_str.format(**dict_map))
                 if not isinstance(self.evaluated_arith,

--- a/specviz/widgets/plotting.py
+++ b/specviz/widgets/plotting.py
@@ -193,7 +193,7 @@ class PlotWidget(pg.PlotWidget):
         self._is_selected = True
 
         # Listen for model events to add/remove items from the plot
-        self.proxy_model.rowsInserted.connect(self._check_unit_compatibility)
+        self.proxy_model.sourceModel().data_added.connect(self._check_unit_compatibility)
         self.proxy_model.rowsAboutToBeRemoved.connect(
             lambda idx: self.remove_plot(index=idx))
 
@@ -332,15 +332,12 @@ class PlotWidget(pg.PlotWidget):
                 plot_data_item.visible = False
                 plot_data_item.data_item.setEnabled(False)
 
-    def _check_unit_compatibility(self, index, first=None, last=None):
-        if not index.isValid():
-            return
-
-        plot_data_item = self.proxy_model.item_from_index(index)
+    def _check_unit_compatibility(self, item):
+        plot_data_item = self.proxy_model.item_from_id(item.identifier)
 
         if not plot_data_item.are_units_compatible(self.spectral_axis_unit,
                                                    self.data_unit):
-            plot_data_item.setEnabled(False)
+            plot_data_item.data_item.setEnabled(False)
 
     def add_plot(self, item=None, index=None, visible=True, initialize=False):
         """


### PR DESCRIPTION
Fixes an incompatibility checking issue that allowed unitless spectrum objects to go enabled even when they should be disabled.

Fixes #550.