### PR TITLE
Statistics Type Selection

### DIFF
--- a/specviz/plugins/statistics/statistics.ui
+++ b/specviz/plugins/statistics/statistics.ui
@@ -14,31 +14,6 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
-    <widget class="QPlainTextEdit" name="status_display">
-     <property name="minimumSize">
-      <size>
-       <width>230</width>
-       <height>192</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>192</height>
-      </size>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">background-color: rgba(255, 255, 255, 0);</string>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
    <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
@@ -53,360 +28,28 @@
     </spacer>
    </item>
    <item row="2" column="0">
-    <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
-     <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="7" column="0">
+      <widget class="QLabel" name="count_total_label">
+       <property name="toolTip">
+        <string>specutils.analysis.flux.line_flux</string>
+       </property>
+       <property name="text">
+        <string>Count total</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
       <widget class="QLabel" name="mean_label">
        <property name="toolTip">
         <string>astropy.units.quantity.Quantity.mean</string>
        </property>
        <property name="text">
-        <string>Mean</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QPlainTextEdit" name="mean_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="median_label">
-       <property name="toolTip">
-        <string>numpy.median</string>
-       </property>
-       <property name="text">
-        <string>Median</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QPlainTextEdit" name="median_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="std_dev_label">
-       <property name="toolTip">
-        <string>astropy.units.quantity.Quantity.std</string>
-       </property>
-       <property name="text">
-        <string>Std Dev</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QPlainTextEdit" name="std_dev_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="centroid_label">
-       <property name="toolTip">
-        <string>specutils.analysis.location.centroid</string>
-       </property>
-       <property name="text">
-        <string>Centroid</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QPlainTextEdit" name="centroid_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="rmsLabel">
-       <property name="toolTip">
-        <string>np.sqrt(flux.dot(flux) / len(flux))</string>
-       </property>
-       <property name="text">
-        <string>RMS</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QPlainTextEdit" name="rms_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="snr_label">
-       <property name="toolTip">
-        <string>specutils.analysis.uncertainty.snr</string>
-       </property>
-       <property name="text">
-        <string>SNR</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QPlainTextEdit" name="snr_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="fwhm_label">
-       <property name="toolTip">
-        <string>specutils.analysis.width.fwhm</string>
-       </property>
-       <property name="text">
-        <string>FWHM</string>
+        <string>Mean Flux</string>
        </property>
       </widget>
      </item>
      <item row="6" column="1">
-      <widget class="QPlainTextEdit" name="fwhm_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="eqwidth_label">
-       <property name="toolTip">
-        <string>specutils.analysis.flux.equivalent_width</string>
-       </property>
-       <property name="text">
-        <string>Eq Width</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QPlainTextEdit" name="eqwidth_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="max_val_label">
-       <property name="toolTip">
-        <string>astropy.units.quantity.Quantity.max</string>
-       </property>
-       <property name="text">
-        <string>Max</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QPlainTextEdit" name="max_val_text_edit">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="verticalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
-       </property>
-       <property name="lineWrapMode">
-        <enum>QPlainTextEdit::NoWrap</enum>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="min_val_label">
-       <property name="toolTip">
-        <string>astropy.units.quantity.Quantity.min</string>
-       </property>
-       <property name="text">
-        <string>Min</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
       <widget class="QPlainTextEdit" name="min_val_text_edit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -434,17 +77,63 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="count_total_label">
-       <property name="toolTip">
-        <string>specutils.analysis.flux.line_flux</string>
+     <item row="3" column="1">
+      <widget class="QPlainTextEdit" name="std_dev_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="text">
-        <string>Count total</string>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="5" column="1">
+      <widget class="QPlainTextEdit" name="max_val_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
       <widget class="QPlainTextEdit" name="count_total_text_edit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -469,6 +158,289 @@
        </property>
        <property name="textInteractionFlags">
         <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QPlainTextEdit" name="fwhm_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QPlainTextEdit" name="eqwidth_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QPlainTextEdit" name="median_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="comboBox"/>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPlainTextEdit" name="mean_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="fwhm_label">
+       <property name="toolTip">
+        <string>specutils.analysis.width.fwhm</string>
+       </property>
+       <property name="text">
+        <string>FWHM</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="median_label">
+       <property name="toolTip">
+        <string>numpy.median</string>
+       </property>
+       <property name="text">
+        <string>Median Flux</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QPlainTextEdit" name="snr_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="snr_label">
+       <property name="toolTip">
+        <string>specutils.analysis.uncertainty.snr</string>
+       </property>
+       <property name="text">
+        <string>SNR</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="centroid_label">
+       <property name="toolTip">
+        <string>specutils.analysis.location.centroid</string>
+       </property>
+       <property name="text">
+        <string>Centroid</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="eqwidth_label">
+       <property name="toolTip">
+        <string>specutils.analysis.flux.equivalent_width</string>
+       </property>
+       <property name="text">
+        <string>Eq Width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="max_val_label">
+       <property name="toolTip">
+        <string>astropy.units.quantity.Quantity.max</string>
+       </property>
+       <property name="text">
+        <string>Max Flux</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Statistics Type</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="min_val_label">
+       <property name="toolTip">
+        <string>astropy.units.quantity.Quantity.min</string>
+       </property>
+       <property name="text">
+        <string>Min Flux</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="std_dev_label">
+       <property name="toolTip">
+        <string>astropy.units.quantity.Quantity.std</string>
+       </property>
+       <property name="text">
+        <string>Std Dev (Flux)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QPlainTextEdit" name="centroid_text_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>24</height>
+        </size>
+       </property>
+       <property name="verticalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="lineWrapMode">
+        <enum>QPlainTextEdit::NoWrap</enum>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0" colspan="2">
+      <widget class="QPlainTextEdit" name="status_display">
+       <property name="minimumSize">
+        <size>
+         <width>230</width>
+         <height>192</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>192</height>
+        </size>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: rgba(255, 255, 255, 0);</string>
+       </property>
+       <property name="frameShape">
+        <enum>QFrame::NoFrame</enum>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/specviz/plugins/statistics/statistics.ui
+++ b/specviz/plugins/statistics/statistics.ui
@@ -433,6 +433,12 @@
          <height>192</height>
         </size>
        </property>
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
        <property name="styleSheet">
         <string notr="true">background-color: rgba(255, 255, 255, 0);</string>
        </property>

--- a/specviz/plugins/statistics/statistics_widget.py
+++ b/specviz/plugins/statistics/statistics_widget.py
@@ -65,12 +65,6 @@ def compute_stats(spectrum):
         cent = "Error"
 
     try:
-        rms = np.sqrt(spectrum.flux.dot(spectrum.flux) / len(spectrum.flux))
-    except Exception as e:
-        logging.debug(e)
-        rms = "Error"
-
-    try:
         snr_val = snr(spectrum)
     except Exception as e:
         logging.debug(e)
@@ -98,7 +92,6 @@ def compute_stats(spectrum):
             'median': np.median(spectrum.flux),
             'stddev': spectrum.flux.std(),
             'centroid': cent,
-            'rms': rms,
             'snr': snr_val,
             'fwhm': fwhm_val,
             'ew': ew,
@@ -150,7 +143,6 @@ class StatisticsWidget(QWidget):
             'median': self.median_text_edit,
             'stddev': self.std_dev_text_edit,
             'centroid': self.centroid_text_edit,
-            'rms': self.rms_text_edit,
             'snr': self.snr_text_edit,
             'fwhm': self.fwhm_text_edit,
             'ew': self.eqwidth_text_edit,
@@ -158,6 +150,18 @@ class StatisticsWidget(QWidget):
             'maxval': self.max_val_text_edit,
             'total': self.count_total_text_edit
         }
+
+        self.continuum_subtracted_widgets = [
+            self.centroid_text_edit,
+            self.centroid_label,
+            self.fwhm_text_edit,
+            self.fwhm_label
+        ]
+
+        self.continuum_normalized_widgets = [
+            self.eqwidth_label,
+            self.eqwidth_text_edit,
+        ]
 
         # Set ui line height based on the current platform's qfont info
         for widget in self.stat_widgets.values():
@@ -168,6 +172,9 @@ class StatisticsWidget(QWidget):
                         (doc.documentMargin() + widget.frameWidth()) * 2 +
                         margins.top() + margins.bottom())
             widget.setFixedHeight(n_height)
+        self.comboBox.addItems(["Generic", "Continuum Subtracted", "Continuum Normalized"])
+        self.comboBox.currentIndexChanged.connect(self._on_set_statistics_type)
+        self._on_set_statistics_type()
 
     def _connect_plot_window(self, plot_window):
         plot_window.plot_widget.plot_added.connect(self.update_statistics)
@@ -181,6 +188,23 @@ class StatisticsWidget(QWidget):
     def clear_status(self):
         self.set_status("")
 
+    def _on_set_statistics_type(self, index=0):
+        stats_type = self.comboBox.currentText()
+        is_subtracted = stats_type == "Continuum Subtracted"
+        is_normalized = stats_type == "Continuum Normalized"
+
+        for widget in self.continuum_subtracted_widgets:
+            if is_subtracted:
+                widget.show()
+            else:
+                widget.hide()
+
+        for widget in self.continuum_normalized_widgets:
+            if is_normalized:
+                widget.show()
+            else:
+                widget.hide()
+
     def _update_stat_widgets(self, stats):
         """
         Clears all widgets then fills in
@@ -192,6 +216,7 @@ class StatisticsWidget(QWidget):
             Value: float value to display
         """
         self._clear_stat_widgets()
+
         if stats is None:
             return
         for key in stats:
@@ -255,10 +280,11 @@ class StatisticsWidget(QWidget):
             return "Data: {0}".format(current_item.name)
         else:
             return "Data: {0}\n" \
-                   "Region Max: {1:0.5g}\n" \
-                   "Region Min: {2:0.5g}".format(current_item.name,
-                                                 region.upper,
-                                                 region.lower)
+                   "Statistics over single region:\n" \
+                   "Region Upper: {1:0.5g}\n" \
+                   "Region Lower: {2:0.5g}".format(current_item.name,
+                                                   region.upper,
+                                                   region.lower)
 
     def clear_statistics(self):
         self._clear_stat_widgets()

--- a/specviz/plugins/statistics/statistics_widget.py
+++ b/specviz/plugins/statistics/statistics_widget.py
@@ -119,7 +119,7 @@ class StatisticsWidget(QWidget):
 
         self.hub.workspace.current_item_changed.connect(self.update_statistics)
         # When the current subwindow changes, update the stat widget
-        self.hub.workspace.mdi_area.subWindowActivated.connect(self.update_statistics)
+        self.hub.workspace.plot_window_activated.connect(self.update_statistics)
         # When current item changes, update the stat widget
         self.hub.workspace.current_item_changed.connect(self.update_statistics)
         # When selection changes, update the stat widget
@@ -277,10 +277,11 @@ class StatisticsWidget(QWidget):
         if current_item is None or not hasattr(current_item, "name"):
             return ""
         if region is None:
-            return "Data: {0}".format(current_item.name)
+            return "Statistics over entire data.\n" \
+                   "Data: {0}".format(current_item.name)
         else:
-            return "Data: {0}\n" \
-                   "Statistics over single region:\n" \
+            return "Statistics over single region.\n" \
+                   "Data: {0}\n" \
                    "Region Upper: {1:0.5g}\n" \
                    "Region Lower: {2:0.5g}".format(current_item.name,
                                                    region.upper,

--- a/specviz/plugins/statistics/statistics_widget.py
+++ b/specviz/plugins/statistics/statistics_widget.py
@@ -378,7 +378,6 @@ class StatisticsWidget(QWidget):
         self.stats = compute_stats(spec)
         self._update_stat_widgets(self.stats)
         self.set_status(self._get_target_name())
-        print("self.sender()", self.sender())
 
     def update_signal_handler(self, *args, **kwargs):
         """

--- a/specviz/plugins/statistics/statistics_widget.py
+++ b/specviz/plugins/statistics/statistics_widget.py
@@ -172,7 +172,7 @@ class StatisticsWidget(QWidget):
                         (doc.documentMargin() + widget.frameWidth()) * 2 +
                         margins.top() + margins.bottom())
             widget.setFixedHeight(n_height)
-        self.comboBox.addItems(["Generic", "Continuum Subtracted", "Continuum Normalized"])
+        self.comboBox.addItems(["Basic", "Continuum Subtracted", "Continuum Normalized"])
         self.comboBox.currentIndexChanged.connect(self._on_set_statistics_type)
         self._on_set_statistics_type()
 

--- a/specviz/plugins/statistics/statistics_widget.py
+++ b/specviz/plugins/statistics/statistics_widget.py
@@ -363,6 +363,9 @@ class StatisticsWidget(QWidget):
                     self.set_status("Region over single value.")
                     return self.clear_statistics()
                 spec = extract_region(spec, spectral_region)
+                if not len(spec.flux) > 0:
+                    self.set_status("Regione range is too small.")
+                    return self.clear_statistics()
             except ValueError as e:
                 self.set_status("Region could not be extracted "
                                 "from target data.")
@@ -375,6 +378,7 @@ class StatisticsWidget(QWidget):
         self.stats = compute_stats(spec)
         self._update_stat_widgets(self.stats)
         self.set_status(self._get_target_name())
+        print("self.sender()", self.sender())
 
     def update_signal_handler(self, *args, **kwargs):
         """

--- a/specviz/plugins/statistics/tests/test_statistics_gui.py
+++ b/specviz/plugins/statistics/tests/test_statistics_gui.py
@@ -22,7 +22,6 @@ def test_statistics_gui_full_spectrum(specviz_gui):
                   'median': np.median(spectrum.flux),
                   'stddev': spectrum.flux.std(),
                   'centroid': centroid(spectrum, region=None),
-                  'rms': np.sqrt(spectrum.flux.dot(spectrum.flux) / len(spectrum.flux)),
                   'snr': "N/A",
                   'fwhm': fwhm(spectrum),
                   'ew': equivalent_width(spectrum),
@@ -54,8 +53,6 @@ def test_statistics_gui_roi_spectrum(specviz_gui):
                   'median': np.median(spectrum.flux),
                   'stddev': spectrum.flux.std(),
                   'centroid': centroid(spectrum, region=None),
-                  'rms': np.sqrt(
-                      spectrum.flux.dot(spectrum.flux) / len(spectrum.flux)),
                   'snr': "N/A",
                   'fwhm': fwhm(spectrum),
                   'ew': equivalent_width(spectrum),

--- a/specviz/widgets/workspace.py
+++ b/specviz/widgets/workspace.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 from astropy.io import registry as io_registry
-from astropy.io.registry import IORegistryError, identify_format, get_reader
 from qtpy import compat
 from qtpy.QtCore import QEvent, Qt, Signal
 from qtpy.QtWidgets import (QApplication, QMainWindow, QMenu,
@@ -36,6 +35,7 @@ class Workspace(QMainWindow):
     current_item_changed = Signal(PlotDataItem)
     current_selected_changed = Signal(PlotDataItem)
     plot_window_added = Signal(PlotWindow)
+    plot_window_activated = Signal(PlotWindow)
 
     def __init__(self, *args, **kwargs):
         super(Workspace, self).__init__(*args, **kwargs)
@@ -302,6 +302,9 @@ class Workspace(QMainWindow):
         # Re-evaluate plot unit compatibilities
         window.plot_widget.check_plot_compatibility()
 
+        # Fire a signal letting everyone know a new plot window has been added
+        self.plot_window_activated.emit(window)
+
     def _on_toggle_visibility(self, state):
         idx = self.list_view.currentIndex()
         item = self.proxy_model.data(idx, role=Qt.UserRole)
@@ -323,38 +326,27 @@ class Workspace(QMainWindow):
         :class:`~specutils.Spectrum1D` object and thereafter adds it to the
         data model.
         """
-        # Create a dictionary mapping the registry loader names to the
-        # qt-specified loader names
-        def compose_filter_string(reader):
-            return ' '.join(['*.{}'.format(y) for y in reader.extensions]
-                            if reader.extensions is not None else '*')
-
-        loader_name_map = {
-            '{} ({})'.format(
-                x['Format'], compose_filter_string(
-                    get_reader(x['Format'], Spectrum1D))): x['Format']
-            for x in io_registry.get_formats(Spectrum1D) if x['Read'] == 'Yes'}
-
-        # Include an auto load function that lets the io machinery find the
-        # most appropriate loader to use
-        loader_name_map['Auto (*)'] = None
-
         # This ensures that users actively have to select a file type before
         # being able to select a file. This should make it harder to
         # accidentally load a file using the wrong type, which results in weird
         # errors.
-        filters = ['Select loader...'] + list(loader_name_map.keys())
+        default_filter = '-- Select file type --'
+
+        filters = [default_filter] + [x['Format'] + " (*)"
+                   for x in io_registry.get_formats(Spectrum1D)
+                   if x['Read'] == 'Yes']
 
         file_path, fmt = compat.getopenfilename(parent=self,
                                                 caption="Load spectral data file",
-                                                filters=";;".join(filters))
+                                                filters=";;".join(filters),
+                                                selectedfilter=default_filter)
 
         if not file_path:
             return
 
-        self.load_data(file_path, file_loader=loader_name_map[fmt])
+        self.load_data(file_path, file_loader=" ".join(fmt.split()[:-1]))
 
-    def load_data(self, file_path, file_loader=None, display=False):
+    def load_data(self, file_path, file_loader, display=False):
         """
         Load spectral data given file path and loader.
 
@@ -372,30 +364,8 @@ class Workspace(QMainWindow):
         : :class:`~specviz.core.items.DataItem`
             The `DataItem` instance that has been added to the internal model.
         """
-        # In the case that the user has selected auto load, loop through every
-        # available loader and choose the one that 1) the registry identifier
-        # function allows, and 2) is the highest priority.
         try:
-            try:
-                spec = Spectrum1D.read(file_path, format=file_loader)
-            except IORegistryError as e:
-                # In this case, assume that the registry has found several
-                # loaders that fit the same identifier, choose the highest
-                # priority one.
-                fmts = identify_format('read', Spectrum1D, file_path, None, [], {})
-
-                logging.warning(e)
-                logging.warning("Loaders for '%s' matched for this data set. "
-                                "Iterating based on priority."
-                                "", ', '.join(fmts))
-
-                for fmt in fmts:
-                    try:
-                        spec = Spectrum1D.read(file_path, format=fmt)
-                    except:
-                        logging.warning("Attempted load with '%s' failed, "
-                                        "trying next loader.", fmt)
-
+            spec = Spectrum1D.read(file_path, format=file_loader)
             name = file_path.split('/')[-1].split('.')[0]
             data_item = self.model.add_data(spec, name=name)
 

--- a/specviz/widgets/workspace.py
+++ b/specviz/widgets/workspace.py
@@ -303,7 +303,7 @@ class Workspace(QMainWindow):
         # Re-evaluate plot unit compatibilities
         window.plot_widget.check_plot_compatibility()
 
-        # Fire a signal letting everyone know a new plot window has been added
+        # Fire a signal letting everyone know a plot window has been activated
         self.plot_window_activated.emit(window)
 
     def _on_toggle_visibility(self, state):


### PR DESCRIPTION
This PR introduces the following 

- Closes #572 : Add combo box to select stats type as discussed in #572 

- Adds `plot_window_activated` signal that fires when a new plot sub-window is opened. This fixes the lag that occurs when moving an ROI. i.e: the signal I used previously to listen to plot window activations was also firing for other events.

- Update the ROI info box to indicate that its stats over a single ROI. Improve range labels of the ROI.
