### PR TITLE
Add tests for loading JWST data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,9 @@ env:
         - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - MAIN_CMD='python setup.py'
-        - SETUP_CMD='test'
+        - SETUP_CMD='python setup.py'
+        - DATA_TEST_PATH='specviz/tests/test_load_data.py'
+        - CMD=test
         - EVENT_TYPE='pull_request push'
 
 
@@ -56,8 +57,8 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 CMD="$SETUP_CMD egg_info"
+        - PYTHON_VERSION=3.7 CMD="$SETUP_CMD egg_info"
 
 
 matrix:
@@ -68,7 +69,6 @@ matrix:
     include:
         # Try MacOS X
         - os: osx
-          env: SETUP_CMD='test'
 
         # Re-enable once coverage is set up for this repository
         ## Do a coverage test.
@@ -78,7 +78,7 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - os: linux
-          env: SETUP_CMD='build_docs -w'
+          env: CMD="$SETUP_CMD build_docs -w"
 
         # Now try Astropy dev with the latest Python and LTS with Python 2.7 and 3.x.
         - os: linux
@@ -87,8 +87,7 @@ matrix:
 
         # Test with glue installed
         - os: linux
-          env: SETUP_CMD='test'
-               PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.1 sphinx-astropy pytest-astropy pytest-qt glue-core'
+          env: PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.1 sphinx-astropy pytest-astropy pytest-qt glue-core'
 
         # Test with latest stable versions of dependencies
         - os: linux
@@ -100,13 +99,13 @@ matrix:
 
         # Do a PEP8 test with pycodestyle
         - os: linux
-          env: MAIN_CMD='pycodestyle specviz --count' SETUP_CMD=''
+          env: CMD='pycodestyle specviz --count'
 
     allow_failures:
         # Do a PEP8 test with pycodestyle
         # (allow to fail unless your code completely compliant)
         - os: linux
-          env: MAIN_CMD='pycodestyle specviz --count' SETUP_CMD=''
+          env: CMD='pycodestyle specviz --count'
 
 install:
 
@@ -134,9 +133,18 @@ install:
     # other dependencies.
 
 script:
-   - $MAIN_CMD $SETUP_CMD
+  # We do two separate test runs: one runs the main test suite where all tests
+  # share the same specviz application instance. The second runs only the JWST
+  # data loader tests, which each run in a separate subprocess.  These two
+  # different test cases do not play nicely when they run in the same pytest
+  # process, which is the reason for separating them here.
+  - if [[ $CMD == test ]]; then
+      $SETUP_CMD test && JWST_DATA_TEST=1 $SETUP_CMD test -t $DATA_TEST_PATH;
+    else
+      $CMD;
+    fi
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line below.
     # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='specviz/tests/coveragerc'; fi
+    # - if [[ $CMD == *coverage* ]]; then coveralls --rcfile='specviz/tests/coveragerc'; fi

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -51,7 +51,7 @@ JWST_DATA_PATHS = [urljoin(BOX_PREFIX, name) for name in JWST_DATA_FILES]
 def load_jwst_data(url):
     try:
         spec_app = Application([], skip_splash=True)
-        data = spec_app.current_workspace.load_data(url, _interactive=False)
+        data = spec_app.current_workspace.load_data(url)
         # Basic sanity check to make sure there are data items
         assert len(data) > 0
     finally:

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -50,7 +50,7 @@ JWST_DATA_PATHS = [urljoin(BOX_PREFIX, name) for name in JWST_DATA_FILES]
 def load_jwst_data(url):
     try:
         spec_app = Application([], skip_splash=True)
-        data = spec_app.current_workspace.load_data(url)
+        data = spec_app.current_workspace.load_data(url, _interactive=False)
         # Basic sanity check to make sure there are data items
         assert len(data) > 0
     finally:

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import traceback
 from urllib.parse import urljoin
@@ -69,6 +70,10 @@ def run_specviz_subprocess(q, url):
     q.put(error)
 
 
+@pytest.mark.skipif(not os.environ.get('JWST_DATA_TEST'),
+                    reason='Since these tests run in a subprocess they do not '
+                    'play nicely with the fixture that is used for the rest of '
+                    'the test suite.')
 @pytest.mark.parametrize('url', JWST_DATA_PATHS)
 def test_load_jwst_data(url):
 

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -89,3 +89,4 @@ def test_load_jwst_data(url):
         ex_type, ex_value, tb_str = error
         message = '{} (in subprocess)\n{}'.format(ex_value, tb_str)
         raise ex_type(message)
+

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -1,0 +1,86 @@
+import sys
+import traceback
+from urllib.parse import urljoin
+from multiprocessing import Process, Queue
+
+import pytest
+
+from specviz.app import Application
+
+
+BOX_PREFIX = 'https://stsci.box.com/shared/static/'
+
+JWST_DATA_FILES = [
+    # NIRISS WFSS
+    # jw87600017001_02101_00002_nis_x1d_ref.fits
+    'fuq1816pljilritjt010un9c0xflxg46.fits',
+    # NIRISS SOSS (lvl 2 data)
+    # jw10003001002_03101_00001-seg003_nis_x1dints_ref.fits
+    'bex0rs8gkqt22sip2z5kvteecutd3czl.fits',
+    # NIRSpec Fixed Slit (lvl 2 data)
+    # jw00023001001_01101_00001_NRS1_x1d_ref.fits
+    '3b01kkv5ndndtja4c7c748mwln7eyt2a.fits',
+    # NIRSpec MSA (lvl 2 data)
+    # f170lp-g235m_mos_observation-6-c0e0_001_dn_nrs1_mod_x1d_ref.fits
+    'v1h9jpg24rusalpui2jpqyldlrqjmv7k.fits',
+    # NIRSpec BOTS (bright object time series)  (lvl 2 data)
+    # jw84600042001_02101_00001_nrs2_x1dints_ref.fits
+    '7yhueeu7yheektf5i48hctocyg9dvfdh.fits',
+    # MIRI IFU (lvl 2)
+    # jw10001001001_01101_00001_mirifushort_x1d_ref.fits
+    'e4c1d8e6prj8e8wpsl1o21w4amnbqj41.fits',
+    # MIRI IFU (lvl 3)
+    # det_image_ch1-short_x1d_ref.fits
+    'bc5vy68irzcgdmuzjpcqoqzvh2qpbc7u.fits',
+    # MIRI LRS Slitless time-series  (lvl 2)
+    # jw80600012001_02101_00003_mirimage_x1dints_ref.fits
+    '6r10ofl8usxqbloen7ostwrudesddyoa.fits',
+    # MIRI LRS Fixed-slit time-series   (lvl 2)
+    # jw00035001001_01101_00001_MIRIMAGE_x1dints_ref.fits
+    '573161xpuzmni12if9dxf0ro1mvx6wy8.fits',
+    # MIRI LRS Fixed-slit   (lvl 2)
+    # jw00035001001_01101_00001_MIRIMAGE_x1d_ref.fits
+    'leyplx2pmh525rsv88lodmtn064uzs68.fits'
+    # TODO: add NIRSpec IFU (lvl 2 data)
+]
+
+JWST_DATA_PATHS = [urljoin(BOX_PREFIX, name) for name in JWST_DATA_FILES]
+
+
+def load_jwst_data(url):
+    try:
+        spec_app = Application([], skip_splash=True)
+        data = spec_app.current_workspace.load_data(url)
+        # Basic sanity check to make sure there are data items
+        assert len(data) > 0
+    finally:
+        spec_app.quit()
+
+
+def run_specviz_subprocess(q, url):
+    try:
+        load_jwst_data(url)
+    except Exception:
+        ex_type, ex_value, tb = sys.exc_info()
+        error = ex_type, ex_value, ''.join(traceback.format_tb(tb))
+    else:
+        error = None
+
+    q.put(error)
+
+
+@pytest.mark.parametrize('url', JWST_DATA_PATHS)
+def test_load_jwst_data(url):
+
+    q = Queue()
+    # Running multiple subsequent Qt applications in the same process seems to
+    # cause segfaults, so we run each specviz instance in a separate process
+    p = Process(target=run_specviz_subprocess, args=(q, url))
+    p.start()
+    error = q.get()
+    p.join()
+
+    if error:
+        ex_type, ex_value, tb_str = error
+        message = '{} (in subprocess)\n{}'.format(ex_value, tb_str)
+        raise ex_type(message)

--- a/specviz/widgets/workspace.py
+++ b/specviz/widgets/workspace.py
@@ -452,7 +452,8 @@ class Workspace(QMainWindow):
 
         return data_item
 
-    def load_data(self, file_path, file_loader=None, display=False):
+    def load_data(self, file_path, file_loader=None, display=False,
+                  _interactive=True):
         """
         Load spectral data given file path and loader.
 
@@ -512,15 +513,18 @@ class Workspace(QMainWindow):
             return data_items
 
         except:
-            message_box = QMessageBox()
-            message_box.setText("Error loading data set.")
-            message_box.setIcon(QMessageBox.Critical)
-            message_box.setInformativeText(
-                "{}\n{}".format(
-                    sys.exc_info()[0], sys.exc_info()[1])
-            )
+            if _interactive:
+                message_box = QMessageBox()
+                message_box.setText("Error loading data set.")
+                message_box.setIcon(QMessageBox.Critical)
+                message_box.setInformativeText(
+                    "{}\n{}".format(
+                        sys.exc_info()[0], sys.exc_info()[1])
+                )
 
-            message_box.exec()
+                message_box.exec()
+            else:
+                raise
 
     def force_plot(self, data_item):
         """

--- a/specviz/widgets/workspace.py
+++ b/specviz/widgets/workspace.py
@@ -367,7 +367,18 @@ class Workspace(QMainWindow):
         if not file_path:
             return
 
-        self.load_data(file_path, file_loader=loader_name_map[fmt])
+        try:
+            self.load_data(file_path, file_loader=loader_name_map[fmt])
+        except:
+            message_box = QMessageBox()
+            message_box.setText("Error loading data set.")
+            message_box.setIcon(QMessageBox.Critical)
+            message_box.setInformativeText(
+                "{}\n{}".format(
+                    sys.exc_info()[0], sys.exc_info()[1])
+            )
+
+            message_box.exec()
 
     def _on_export_data(self):
         """
@@ -452,8 +463,7 @@ class Workspace(QMainWindow):
 
         return data_item
 
-    def load_data(self, file_path, file_loader=None, display=False,
-                  _interactive=True):
+    def load_data(self, file_path, file_loader=None, display=False):
         """
         Load spectral data given file path and loader.
 
@@ -475,56 +485,41 @@ class Workspace(QMainWindow):
         # available loader and choose the one that 1) the registry identifier
         # function allows, and 2) is the highest priority.
         try:
-            try:
-                speclist = SpectrumList.read(file_path, format=file_loader)
-            except IORegistryError as e:
-                # In this case, assume that the registry has found several
-                # loaders that fit the same identifier, choose the highest
-                # priority one.
-                fmts = io_registry.get_formats(Spectrum1D, 'Read')['Format']
+            speclist = SpectrumList.read(file_path, format=file_loader)
+        except IORegistryError as e:
+            # In this case, assume that the registry has found several
+            # loaders that fit the same identifier, choose the highest
+            # priority one.
+            fmts = io_registry.get_formats(Spectrum1D, 'Read')['Format']
 
-                logging.warning("Loaders for '%s' matched for this data set. "
-                                "Iterating based on priority."
-                                "", ', '.join(fmts))
+            logging.warning("Loaders for '%s' matched for this data set. "
+                            "Iterating based on priority."
+                            "", ', '.join(fmts))
 
-                for fmt in fmts:
-                    try:
-                        speclist = SpectrumList.read(file_path, format=fmt)
-                    except:
-                        logging.warning("Attempted load with '%s' failed, "
-                                        "trying next loader.", fmt)
+            for fmt in fmts:
+                try:
+                    speclist = SpectrumList.read(file_path, format=fmt)
+                except:
+                    logging.warning("Attempted load with '%s' failed, "
+                                    "trying next loader.", fmt)
 
-            name = file_path.split('/')[-1].split('.')[0]
+        name = file_path.split('/')[-1].split('.')[0]
 
-            data_items = []
+        data_items = []
 
-            if len(speclist) == 1:
-                data_items.append(self._add_and_plot_data(speclist[0], name))
-            else:
-                for i, spec in enumerate(speclist):
-                    # TODO: try to use more informative metadata in the name
-                    specname = '{}-{}'.format(name, i)
-                    data_items.append(self._add_and_plot_data(spec, specname))
+        if len(speclist) == 1:
+            data_items.append(self._add_and_plot_data(speclist[0], name))
+        else:
+            for i, spec in enumerate(speclist):
+                # TODO: try to use more informative metadata in the name
+                specname = '{}-{}'.format(name, i)
+                data_items.append(self._add_and_plot_data(spec, specname))
 
-            for di in data_items:
-                self.force_plot(di)
+        for di in data_items:
+            self.force_plot(di)
 
-            # TODO: is this return value useful? Potentially just for testing
-            return data_items
-
-        except:
-            if _interactive:
-                message_box = QMessageBox()
-                message_box.setText("Error loading data set.")
-                message_box.setIcon(QMessageBox.Critical)
-                message_box.setInformativeText(
-                    "{}\n{}".format(
-                        sys.exc_info()[0], sys.exc_info()[1])
-                )
-
-                message_box.exec()
-            else:
-                raise
+        # TODO: is this return value useful? Potentially just for testing
+        return data_items
 
     def force_plot(self, data_item):
         """


### PR DESCRIPTION
This resolves #608.

So obviously this took a lot less effort than I originally anticipated, but that's mostly because @SaOgaz had done all of the legwork of gathering the relevant test data and setting it up on Box.

Right now the test simply loads each data file into `specviz` and makes sure that nothing goes wrong. It's possible that we want to add more comprehensive checks to the tests, but I think this is actually a pretty good smoke test for now.

Each test case starts up a new instance of `specviz` in order to make sure we're simulating something like a real user workflow. In order to avoid the Qt segfault issue we discussed earlier in the week, each test case runs `specviz` in a separate process using the `multiprocessing` module. This might be worth using for other test cases as well.