### PR TITLE
Drop support for py35, update travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.6
+        - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
@@ -56,8 +56,8 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
 
 matrix:
@@ -90,17 +90,12 @@ matrix:
           env: SETUP_CMD='test'
                PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.1 sphinx-astropy pytest-astropy pytest-qt glue-core'
 
-        # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different
-        # versions of Python, we can vary Python and Numpy versions at the same
-        # time.
+        # Test with older version of Astropy
+        - os: linux
+          env: PYTHON_VERSION=3.6 ASTROPY_VERSION=3.0
 
+        # Test with latest stable versions of dependencies
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10 ASTROPY_VERSION=3.0
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11 ASTROPY_VERSION=3.0
-        - os: linux
-          env: NUMPY_VERSION=1.12
 
         # Try numpy pre-release
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,6 @@ matrix:
           env: SETUP_CMD='test'
                PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.1 sphinx-astropy pytest-astropy pytest-qt glue-core'
 
-        # Test with older version of Astropy
-        - os: linux
-          env: PYTHON_VERSION=3.6 ASTROPY_VERSION=3.0
-
         # Test with latest stable versions of dependencies
         - os: linux
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -98,7 +98,7 @@ You may also install by cloning the repository directly
 PyQt bindings
 ^^^^^^^^^^^^^
 
-SpecViz requires PyQt. Currently, only python environments with 3.5 or higher
+SpecViz requires PyQt. Currently, only python environments with 3.6 or higher
 installed can use ``pip`` to install PyQt5, in which case simply type::
 
     $ pip install pyqt5

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/specviz
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy>=3.0, pyqt5, pyqtgraph, qtawesome, qtpy, specutils>=0.5.1, click, pytest, asteval
+install_requires = astropy>=3.1, pyqt5, pyqtgraph, qtawesome, qtpy, specutils>=0.5.1, click, pytest, asteval
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.6.dev0
 # Note: you will also need to change this in your package's __init__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires = astropy>=3.0, pyqt5, pyqtgraph, qtawesome, qtpy, specutils>=0
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.6.dev0
 # Note: you will also need to change this in your package's __init__.py
-minimum_python_version = 3.5
+minimum_python_version = 3.6
 
 [entry_points]
 specviz = specviz.app:start

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ AUTHOR = metadata.get('author', 'JDADF Developers')
 AUTHOR_EMAIL = metadata.get('author_email', '')
 LICENSE = metadata.get('license', 'unknown')
 URL = metadata.get('url', 'https://specviz.rtfd.io')
-__minimum_python_version__ = metadata.get("minimum_python_version", "3.5")
+__minimum_python_version__ = metadata.get("minimum_python_version", "3.6")
 
 # Enforce Python version check - this is the same check as in __init__.py but
 # this one has to happen before importing ah_bootstrap.

--- a/specviz/__init__.py
+++ b/specviz/__init__.py
@@ -12,7 +12,7 @@ import os
 import sys
 import logging
 
-__minimum_python_version__ = "3.5"
+__minimum_python_version__ = "3.6"
 
 class UnsupportedPythonError(Exception):
     pass


### PR DESCRIPTION
It appears that `specutils` will only be supporting Py36 and later going forward, and I believe that the same is true of the latest version of Astropy, so this seems like a prudent move. We were also encountering issues with Py35 on travis which seemed to indicate incompatible dependencies