### PR TITLE
Add dialog for selecting which spectra to load

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -103,9 +103,9 @@ view widget.
 | ``plot_window_activated``    | Fired when a PlotWindow becomes active.                                  |
 +------------------------------+--------------------------------------------------------------------------+
 
-|Workspace| objects also contain the methods for providing the Qt dialogs for loading
-data (:func:`~specviz.widgets.workspace.Workspace.load_data`) using the
-``specutils`` IO infrastructure, as well as exporting data
+|Workspace| objects also contain the methods for providing the Qt dialogs for
+loading data (:func:`~specviz.widgets.workspace.Workspace.load_data_from_file`)
+using the ``specutils`` IO infrastructure, as well as exporting data
 (:meth:`~specviz.widgets.workspace.Workspace._on_export_data`), and deleting
 data items (:meth:`~specviz.widgets.workspace.Workspace._on_delete_data`).
 

--- a/specviz/app.py
+++ b/specviz/app.py
@@ -31,7 +31,7 @@ class Application(QApplication):
     workspace_added = Signal(Workspace)
 
     def __init__(self, *args, file_path=None, file_loader=None, embedded=False,
-                 dev=False, skip_splash=False, **kwargs):
+                 dev=False, skip_splash=False, load_all=False, **kwargs):
         super(Application, self).__init__(*args, **kwargs)
 
         # Set application icon
@@ -72,8 +72,9 @@ class Application(QApplication):
         # If a file path has been given, automatically add data
         if file_path is not None:
             try:
-                self.current_workspace.load_data(
-                    file_path, file_loader, display=True)
+                self.current_workspace.load_data_from_file(
+                                            file_path, file_loader=file_loader,
+                                            multi_select=not load_all)
             except Exception as e:
                 self.current_workspace.display_load_data_error(e)
 
@@ -205,8 +206,10 @@ class SplashDialog(QDialog):
 @click.option('--loader', '-L', type=str, help="Use specified loader when opening the provided file.")
 @click.option('--embed', '-E', is_flag=True, help="Only display a single plot window. Useful when embedding in other applications.")
 @click.option('--dev', '-D', is_flag=True, help="Open SpecViz in developer mode. This mode auto-loads example spectral data.")
+@click.option('--load_all', is_flag=True, help="Automatically load all spectra in file instead of displaying spectrum selection dialog")
 @click.option('--version', '-V', is_flag=True, help="Print version information", is_eager=True)
-def start(version=False, file_path=None, loader=None, embed=None, dev=None, hide_splash=False):
+def start(version=False, file_path=None, loader=None, embed=None, dev=None,
+          hide_splash=False, load_all=None):
     """
     The function called when accessed through the command line. Parses any
     command line arguments and provides them to the application instance, or
@@ -233,7 +236,8 @@ def start(version=False, file_path=None, loader=None, embed=None, dev=None, hide
 
     # Start the application, passing in arguments
     app = Application(sys.argv, file_path=file_path, file_loader=loader,
-                      embedded=embed, dev=dev, skip_splash=hide_splash)
+                      embedded=embed, dev=dev, skip_splash=hide_splash,
+                      load_all=load_all)
 
     # Enable hidpi icons
     QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -95,7 +95,7 @@ def test_load_jwst_data(url):
         try:
             spec_app = Application([], skip_splash=True)
             # Use loader auto-detection here
-            data = spec_app.current_workspace.load_data(url)
+            data = spec_app.current_workspace.load_data_from_file(url, multi_select=False)
             # Basic sanity check to make sure there are data items
             assert len(data) > 0
         finally:
@@ -116,7 +116,9 @@ def test_valid_loader(tmpdir):
 
     def use_valid_loader(fname):
         spec_app = Application([], skip_splash=True)
-        spec_app.current_workspace.load_data(fname, file_loader='HST/COS')
+        spec_app.current_workspace.load_data_from_file(fname,
+                                                       file_loader='HST/COS',
+                                                       multi_select=False)
 
     run_subprocess_test(use_valid_loader, fname)
 
@@ -137,7 +139,8 @@ def test_invalid_data_file(tmpdir):
     def open_invalid_data(fname):
         spec_app = Application([], skip_splash=True)
         with pytest.raises(IOError) as err:
-            spec_app.current_workspace.load_data(fname)
+            spec_app.current_workspace.load_data_from_file(fname,
+                                                           multi_select=False)
             assert err.msg.startswith('Could not find appropriate loader')
 
     run_subprocess_test(open_invalid_data, fname)
@@ -161,7 +164,9 @@ def test_invalid_loader(url, tmpdir):
         spec_app = Application([], skip_splash=True)
         with pytest.raises(IOError) as err:
             # Using the HST/COS loader is not appropriate for a JWST data file
-            spec_app.current_workspace.load_data(fname, file_loader='HST/COS')
+            spec_app.current_workspace.load_data_from_file(fname,
+                                                           file_loader='HST/COS',
+                                                           multi_select=False)
             assert err.msg.startswith(
                  'Given file can not be processed as specified file format')
             assert 'HST/COS' in err.msg
@@ -182,7 +187,9 @@ def test_nonexistent_loader(tmpdir):
     def use_valid_loader(fname):
         spec_app = Application([], skip_splash=True)
         with pytest.raises(IOError) as err:
-            spec_app.current_workspace.load_data(fname, file_loader='FAKE')
+            spec_app.current_workspace.load_data_from_file(fname,
+                                                           file_loader='FAKE',
+                                                           multi_select=False)
             assert err.msg.startswith(
                  'Given file can not be processed as specified file format')
             assert 'FAKE' in err.msg

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -195,3 +195,24 @@ def test_nonexistent_loader(tmpdir):
             assert 'FAKE' in err.msg
 
     run_subprocess_test(use_valid_loader, fname)
+
+
+@jwst_data_test
+def test_load_data_command_line(tmpdir):
+    """
+    Test to simulate the case where a data file is provided on the command line
+    """
+
+    fname = str(tmpdir.join('data.fits'))
+
+    with fits.open(JWST_DATA_PATHS[0]) as hdulist:
+        hdulist.writeto(fname)
+
+    def load_data_command_line(*args):
+        try:
+            spec_app = Application([], file_path=args[0], skip_splash=True,
+                                   load_all=True)
+        finally:
+            spec_app.quit()
+
+    run_subprocess_test(load_data_command_line, fname)

--- a/specviz/widgets/spectrum_selection.py
+++ b/specviz/widgets/spectrum_selection.py
@@ -14,7 +14,7 @@ class SpectrumSelection(QDialog):
             os.path.join(os.path.dirname(__file__),
                          "ui", "spectrum_selection.ui")), self)
 
-        self.setWindowTitle('Select Spectra to Load')
+        self.setWindowTitle('Spectrum Selection')
 
         self._model = QStandardItemModel(self.spectrumList)
         self.spectrumList.setModel(self._model)

--- a/specviz/widgets/spectrum_selection.py
+++ b/specviz/widgets/spectrum_selection.py
@@ -35,7 +35,7 @@ class SpectrumSelection(QDialog):
 
     def populate(self, names):
         """
-        Add a list of names to be displayed as list items in the dialog 
+        Add a list of names to be displayed as list items in the dialog
 
         Parameters
         ----------

--- a/specviz/widgets/spectrum_selection.py
+++ b/specviz/widgets/spectrum_selection.py
@@ -1,0 +1,69 @@
+import os
+
+from qtpy.uic import loadUi
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QDialog
+from qtpy.QtGui import QStandardItemModel, QStandardItem
+
+
+class SpectrumSelection(QDialog):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        loadUi(os.path.abspath(
+            os.path.join(os.path.dirname(__file__),
+                         "ui", "spectrum_selection.ui")), self)
+
+        self.setWindowTitle('Select Spectra to Load')
+
+        self._model = QStandardItemModel(self.spectrumList)
+        self.spectrumList.setModel(self._model)
+        self._selected = False
+
+        self.buttonBox.accepted.connect(self._confirm_selection)
+
+        self.selectAllButton.clicked.connect(self._select_all)
+        self.deselectAllButton.clicked.connect(self._deselect_all)
+
+    def populate(self, spectra):
+        for s in spectra:
+            item = QStandardItem(s)
+            item.setCheckable(True)
+            item.setCheckState(Qt.Checked)
+            self._model.appendRow(item)
+
+    def get_selected(self):
+        if not self._selected:
+            return []
+
+        selected = []
+        for i in range(self._model.rowCount()):
+            item = self._model.item(i)
+            if item.checkState() == Qt.Checked:
+                selected.append(item.text())
+        return selected
+
+    def _confirm_selection(self):
+        self._selected = True
+
+    def _select_all(self):
+        for i in range(self._model.rowCount()):
+            item = self._model.item(i)
+            item.setCheckState(Qt.Checked)
+
+    def _deselect_all(self):
+        for i in range(self._model.rowCount()):
+            item = self._model.item(i)
+            item.setCheckState(Qt.Unchecked)
+
+
+if __name__ == '__main__': # noqa
+
+    import sys
+    from qtpy.QtWidgets import QApplication
+
+    app = QApplication([])
+    s = SpectrumSelection()
+    s.populate(['a', 'b', 'c', 'd', 'e', 'f'])
+    s.show()
+    app.exec_()

--- a/specviz/widgets/spectrum_selection.py
+++ b/specviz/widgets/spectrum_selection.py
@@ -7,6 +7,14 @@ from qtpy.QtGui import QStandardItemModel, QStandardItem
 
 
 class SpectrumSelection(QDialog):
+    """
+    A widget providing a simple dialog for selecting spectra to be loaded.
+
+    The widget itself knows nothing about spectral data objects, but instead
+    just presents a list of strings which represent the names of the available
+    spectra, and returns a list of strings which represent the names of the
+    spectra that were actually selected.
+    """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -25,14 +33,35 @@ class SpectrumSelection(QDialog):
         self.selectAllButton.clicked.connect(self._select_all)
         self.deselectAllButton.clicked.connect(self._deselect_all)
 
-    def populate(self, spectra):
-        for s in spectra:
+    def populate(self, names):
+        """
+        Add a list of names to be displayed as list items in the dialog 
+
+        Parameters
+        ----------
+        names : `list`
+            The list of names to be populated in the dialog
+        """
+        for s in names:
             item = QStandardItem(s)
             item.setCheckable(True)
             item.setCheckState(Qt.Checked)
             self._model.appendRow(item)
 
     def get_selected(self):
+        """
+        Get the list of names that were actually checked when the dialog closes
+
+        This method will return an empty list in the following cases:
+            * No items were selected when the dialog closes
+            * The "Cancel" button was hit by the user instead of "Open"
+            * This method is called before the dialog closes
+
+        Returns
+        -------
+        names : `list`
+            The list of names that were selected when the dialog closes
+        """
         if not self._selected:
             return []
 
@@ -58,7 +87,7 @@ class SpectrumSelection(QDialog):
 
 
 if __name__ == '__main__': # noqa
-
+    # This code is purely for enabling development and debugging of the widget
     import sys
     from qtpy.QtWidgets import QApplication
 

--- a/specviz/widgets/tests/test_spectrum_selection.py
+++ b/specviz/widgets/tests/test_spectrum_selection.py
@@ -1,0 +1,81 @@
+from qtpy.QtCore import Qt
+
+from ..spectrum_selection import SpectrumSelection
+
+
+def test_spectrum_selection(specviz_gui):
+
+    spec_select = SpectrumSelection(specviz_gui.current_workspace)
+
+    # Check starting state
+    assert spec_select._selected == False
+    assert spec_select._model.rowCount() == 0
+
+    # Populate with some arbitrary names
+    names = ['a', 'b', 'c', 'd', 'e', 'f']
+    spec_select.populate(names)
+    assert spec_select._model.rowCount() == len(names)
+
+    # Simulate the action that occurs when clicking "Open"
+    spec_select._confirm_selection()
+    assert spec_select._selected == True
+    assert spec_select.get_selected() == names
+
+    spec_select.close()
+
+
+def test_deselect_all(qtbot, specviz_gui):
+
+    spec_select = SpectrumSelection(specviz_gui.current_workspace)
+
+    # Populate with some arbitrary names
+    names = ['a', 'b', 'c', 'd', 'e', 'f']
+    spec_select.populate(names)
+
+    qtbot.mouseClick(spec_select.deselectAllButton, Qt.LeftButton)
+    # Simulate the action that occurs when clicking "Open"
+    spec_select._confirm_selection()
+
+    assert spec_select.get_selected() == []
+
+    spec_select.close()
+
+
+def test_deselect_one(specviz_gui):
+
+    spec_select = SpectrumSelection(specviz_gui.current_workspace)
+
+    names = ['a', 'b', 'c', 'd', 'e', 'f']
+    spec_select.populate(names)
+
+    # Simulate unchecking a single item from the list
+    item = spec_select._model.item(1)
+    item.setCheckState(Qt.Unchecked)
+
+    # Simulate the action that occurs when clicking "Open"
+    spec_select._confirm_selection()
+    assert spec_select.get_selected() == names[:1] + names[2:]
+
+    spec_select.close()
+
+
+def test_select_all(qtbot, specviz_gui):
+
+    spec_select = SpectrumSelection(specviz_gui.current_workspace)
+
+    names = ['a', 'b', 'c', 'd', 'e', 'f']
+    spec_select.populate(names)
+
+    # 'Manually' uncheck all of the boxes in the list
+    for index in range(spec_select._model.rowCount()):
+        item = spec_select._model.item(index)
+        item.setCheckState(Qt.Unchecked)
+
+    # Now click the 'Select All' button
+    qtbot.mouseClick(spec_select.selectAllButton, Qt.LeftButton)
+    # Simulate the action that occurs when clicking "Open"
+    spec_select._confirm_selection()
+
+    assert spec_select.get_selected() == names
+
+    spec_select.close()

--- a/specviz/widgets/ui/spectrum_selection.ui
+++ b/specviz/widgets/ui/spectrum_selection.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>398</width>
+    <width>396</width>
     <height>304</height>
    </rect>
   </property>
@@ -18,11 +18,21 @@
     <rect>
      <x>13</x>
      <y>6</y>
-     <width>381</width>
+     <width>371</width>
      <height>291</height>
     </rect>
    </property>
    <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Select which spectra from the file should be loaded. By default all spectra will be loaded.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
@@ -45,6 +55,9 @@
      <widget class="QListView" name="spectrumList">
       <property name="autoFillBackground">
        <bool>false</bool>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
       </property>
      </widget>
     </item>

--- a/specviz/widgets/ui/spectrum_selection.ui
+++ b/specviz/widgets/ui/spectrum_selection.ui
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>398</width>
+    <height>304</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>13</x>
+     <y>6</y>
+     <width>381</width>
+     <height>291</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="selectAllButton">
+        <property name="text">
+         <string>Select All</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="deselectAllButton">
+        <property name="text">
+         <string>Deselect All</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
+     <widget class="QListView" name="spectrumList">
+      <property name="autoFillBackground">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Open</set>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/specviz/widgets/workspace.py
+++ b/specviz/widgets/workspace.py
@@ -434,7 +434,7 @@ class Workspace(QMainWindow):
         This is a high-level function that is intended to be used both by GUI
         functionality, and also programmatically if necessary. By default, if
         the given file contains multiple spectra, a dialog will be presented to
-        the user to select which spectra to load. If `multi_select=False`, no
+        the user to select which spectra to load. If ``multi_select=False``, no
         dialog will be displayed and all spectra in the file will be loaded.
 
         Parameters
@@ -646,7 +646,7 @@ class Workspace(QMainWindow):
         Returns
         -------
         : :class:`~specutils.SpectrumList`
-            A `SpectrumList` instance containing the spectra loaded from the file
+            A `~specutils.SpectrumList` instance containing the spectra loaded from the file
         """
         # In the case that the user has selected auto load, loop through every
         # available loader and choose the one that 1) the registry identifier


### PR DESCRIPTION
This resolves #609. It provides a dialog that enables users to select which spectra to load from a file that contains multiple spectra.

This is pretty basic at the moment. We may want to consider adding a preview in the future. Also, it would eventually be useful for `specutils` loaders to provide more informative metadata about spectra (probably derived from the HDU headers) so that we could give more informative names to these data items.

The same open file dialog is used:
![image](https://user-images.githubusercontent.com/2458487/51992737-915ed780-247b-11e9-84a5-7bc20f41c878.png)

However, when loading a file with multiple spectra, users now see the following dialog after clicking "Open":
![image](https://user-images.githubusercontent.com/2458487/51992813-ae93a600-247b-11e9-932c-dabd1d1badab.png)

By default, all spectra are selected, so most users can just click "Open" and keep moving.