### PR TITLE
Make data loader handling more correct/robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 
         # List other runtime dependencies for the package that are available as
         # pip packages here.
-        - PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.1 asteval sphinx-astropy sphinx-rtd-theme pytest-astropy pytest-qt'
+        - PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.2 asteval sphinx-astropy sphinx-rtd-theme pytest-astropy pytest-qt'
 
         # Conda packages for affiliated packages are hosted in channel
         # "astropy" while builds for astropy LTS with recent numpy versions
@@ -87,7 +87,7 @@ matrix:
 
         # Test with glue installed
         - os: linux
-          env: PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.1 sphinx-astropy pytest-astropy pytest-qt glue-core'
+          env: PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.2 sphinx-astropy pytest-astropy pytest-qt glue-core'
 
         # Test with latest stable versions of dependencies
         - os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/specviz
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy>=3.1, pyqt5, pyqtgraph, qtawesome, qtpy, specutils>=0.5.1, click, pytest, asteval
+install_requires = astropy>=3.1, pyqt5, pyqtgraph, qtawesome, qtpy, specutils>=0.5.2, click, pytest, asteval
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.6.dev0
 # Note: you will also need to change this in your package's __init__.py

--- a/specviz/tests/test_load_data.py
+++ b/specviz/tests/test_load_data.py
@@ -6,6 +6,8 @@ from multiprocessing import Process, Queue
 
 import pytest
 
+from astropy.io import fits
+
 from specviz.app import Application
 
 
@@ -46,6 +48,12 @@ JWST_DATA_FILES = [
 ]
 
 JWST_DATA_PATHS = [urljoin(BOX_PREFIX, name) for name in JWST_DATA_FILES]
+# This is a valid JWST data file, but not one that can be handled by any of the
+# specutils loaders (since it does not contain spectral data). It is intended
+# to test the fix for the issue reported in
+# https://github.com/spacetelescope/specviz/issues/618
+BAD_DATA_PATH = urljoin(BOX_PREFIX, '71i9r6k95kodcqoc7urwsywu49x3zwci.fits')
+HST_COS_PATH = urljoin(BOX_PREFIX, 'nh3ze6di0lpitz3nn2coj0vgwd9x7mnp.fits')
 
 jwst_data_test = pytest.mark.skipif(
                     not os.environ.get('JWST_DATA_TEST'),
@@ -86,6 +94,7 @@ def test_load_jwst_data(url):
     def load_jwst_data(url):
         try:
             spec_app = Application([], skip_splash=True)
+            # Use loader auto-detection here
             data = spec_app.current_workspace.load_data(url)
             # Basic sanity check to make sure there are data items
             assert len(data) > 0
@@ -93,3 +102,89 @@ def test_load_jwst_data(url):
             spec_app.quit()
 
     run_subprocess_test(load_jwst_data, url)
+
+
+@jwst_data_test
+def test_valid_loader(tmpdir):
+    """
+    Explicitly request to use the appropriate loader for a HST/COS data file
+    """
+
+    fname = str(tmpdir.join('good_data.fits'))
+    with fits.open(HST_COS_PATH) as hdulist:
+        hdulist.writeto(fname)
+
+    def use_valid_loader(fname):
+        spec_app = Application([], skip_splash=True)
+        spec_app.current_workspace.load_data(fname, file_loader='HST/COS')
+
+    run_subprocess_test(use_valid_loader, fname)
+
+
+@jwst_data_test
+def test_invalid_data_file(tmpdir):
+    """
+    Try to open a non-spectral FITS file. It shouldn't load.
+
+    This is to make sure we get a reasonable error from the loader itself
+    rather than an unexpected error later on.
+    """
+
+    fname = str(tmpdir.join('bad_data.fits'))
+    with fits.open(BAD_DATA_PATH) as hdulist:
+        hdulist.writeto(fname)
+
+    def open_invalid_data(fname):
+        spec_app = Application([], skip_splash=True)
+        with pytest.raises(IOError) as err:
+            spec_app.current_workspace.load_data(fname)
+            assert err.msg.startswith('Could not find appropriate loader')
+
+    run_subprocess_test(open_invalid_data, fname)
+
+
+@jwst_data_test
+@pytest.mark.parametrize('url', [JWST_DATA_PATHS[0], BAD_DATA_PATH])
+def test_invalid_loader(url, tmpdir):
+    """
+    Try to open both a valid data file with the wrong loader and an invalid
+    data file with any specific loader (rather than auto-identify).
+
+    We expect to get a reasonable error.
+    """
+
+    fname = str(tmpdir.join('data.fits'))
+    with fits.open(url) as hdulist:
+        hdulist.writeto(fname)
+
+    def use_wrong_loader(fname):
+        spec_app = Application([], skip_splash=True)
+        with pytest.raises(IOError) as err:
+            # Using the HST/COS loader is not appropriate for a JWST data file
+            spec_app.current_workspace.load_data(fname, file_loader='HST/COS')
+            assert err.msg.startswith(
+                 'Given file can not be processed as specified file format')
+            assert 'HST/COS' in err.msg
+
+    run_subprocess_test(use_wrong_loader, fname)
+
+
+@jwst_data_test
+def test_nonexistent_loader(tmpdir):
+    """
+    Try to specify a loader that doesn't exist.
+    """
+
+    fname = str(tmpdir.join('good_data.fits'))
+    with fits.open(HST_COS_PATH) as hdulist:
+        hdulist.writeto(fname)
+
+    def use_valid_loader(fname):
+        spec_app = Application([], skip_splash=True)
+        with pytest.raises(IOError) as err:
+            spec_app.current_workspace.load_data(fname, file_loader='FAKE')
+            assert err.msg.startswith(
+                 'Given file can not be processed as specified file format')
+            assert 'FAKE' in err.msg
+
+    run_subprocess_test(use_valid_loader, fname)


### PR DESCRIPTION
This resolves #618. It is based on #639, which should be merged first. It also depends on a bug fix in `specutils` (see https://github.com/astropy/specutils/pull/440), so the tests will not pass until that is merged and released.

There were three fundamental problems here:
1. Most `specutils` loaders for `SpectrumList` were not providing identifiers. This was a bug and meant that if a user specified the wrong loader, even for a valid data file, the file would be opened but would likely cause a crash somewhere later. This is no longer possible with the `specutils` fix mentioned above.
2. In certain cases, `specviz` was not using identifiers to check whether a particular loader should be used before trying to attempt the file. Now that `specutils` provides identifiers for most cases, they can be used by `specutils` and an appropriate error can be propagated up to the user if no valid loader is available.
3. Prior to #639, loader errors were not being handled properly by `specviz` in all cases, so some loader errors would cause the application to crash (particularly when loading an invalid file from the command line).