### PR TITLE
Use tox for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ matrix:
 
     include:
         # Do a coverage test
-        - env: TOXENV='coverage' TOX_ARGS=''
+        # Skip for now. Eventually we will want to use codecov
+        #- env: TOXENV='coverage' TOX_ARGS=''
 
         # Perform a sanity check of packaging using twine
         - env: TOXENV='twine' TOX_ARGS=''

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ env:
         # Make sure README will display properly on pypi
         - TOXENV='checkdocs'
         # Run a test with stable dependencies
-        - TOXENV='py36'
-        - TOXENV='py37'
+        - TOXENV='py36-test'
+        - TOXENV='py37-test'
 
 
 matrix:
@@ -64,27 +64,27 @@ matrix:
 
         # Try MacOS X and Windows
         - os: osx
-          env: TOXENV='py37'
+          env: TOXENV='py37-test'
 
         - os: windows
-          env: TOXENV='py37'
+          env: TOXENV='py37-test'
 
         - os: linux
-          env: TOXENV='py37-astrodev'
+          env: TOXENV='py37-astrodev-test'
                EVENT_TYPE='pull_request push cron'
 
         - os: linux
-          env: TOXENV='py37-numpydev'
+          env: TOXENV='py37-numpydev-test'
                EVENT_TYPE='pull_request push cron'
 
         # Test with glue installed
         - os: linux
-          env: TOXENV='py37-glue'
+          env: TOXENV='py37-glue-test'
 
     allow_failures:
-        - env: TOXENV='py37-astrodev'
+        - env: TOXENV='py37-astrodev-test'
                EVENT_TYPE='pull_request push cron'
-        - env: TOXENV='py37-numpydev'
+        - env: TOXENV='py37-numpydev-test'
                EVENT_TYPE='pull_request push cron'
 
 install:
@@ -96,3 +96,6 @@ install:
 script:
     - conda info
     - $TOX_CMD $TOX_ARGS
+    - if [[ $TOXENV == *-test ]]; then
+        JWST_DATA_TEST=1 $TOX_CMD specviz/tests/test_load_data.py $TOX_ARGS;
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ matrix:
           env: TOXENV='py37-glue-test'
 
     allow_failures:
+        - os: windows
+          env: TOXENV='py37-test'
         - env: TOXENV='py37-astrodev-test'
                EVENT_TYPE='pull_request push cron'
         - env: TOXENV='py37-numpydev-test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,40 +25,22 @@ env:
     global:
 
         # The following versions are the 'default' for tests, unless
-        # overridden underneath. They are defined here in order to save having
+        # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.7
-        - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=stable
-        - SETUP_CMD='python setup.py'
-        - DATA_TEST_PATH='specviz/tests/test_load_data.py'
-        - CMD=test
+        - TOX_CMD='tox --'
+        - TOX_ARGS='--remote-data'
         - EVENT_TYPE='pull_request push'
-
-
-        # List other runtime dependencies for the package that are available as
-        # conda packages here.
-        - CONDA_DEPENDENCIES=''
-
-        # List other runtime dependencies for the package that are available as
-        # pip packages here.
-        - PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.2 asteval sphinx-astropy sphinx-rtd-theme pytest-astropy pytest-qt'
-
-        # Conda packages for affiliated packages are hosted in channel
-        # "astropy" while builds for astropy LTS with recent numpy versions
-        # are in astropy-ci-extras. If your package uses either of these,
-        # add the channels to CONDA_CHANNELS along with any other channels
-        # you want to use.
-        - CONDA_CHANNELS='astropy-ci-extras astropy'
-
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
         - SETUP_XVFB=True
 
+
     matrix:
-        # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=3.6 CMD="$SETUP_CMD egg_info"
-        - PYTHON_VERSION=3.7 CMD="$SETUP_CMD egg_info"
+        # Make sure that installation does not fail
+        - TOXENV='py37' TOX_CMD='tox --notest' TOX_ARGS=''
+        # Make sure README will display properly on pypi
+        - TOXENV='checkdocs'
+        # Run a test with stable dependencies
+        - TOXENV='py36'
+        - TOXENV='py37'
 
 
 matrix:
@@ -67,85 +49,50 @@ matrix:
     fast_finish: true
 
     include:
-        # Try MacOS X
-        - os: osx
+        # Do a coverage test
+        - env: TOXENV='coverage' TOX_ARGS=''
 
-        # Re-enable once coverage is set up for this repository
-        ## Do a coverage test.
-        #- os: linux
-        #  env: SETUP_CMD='test --coverage'
+        # Perform a sanity check of packaging using twine
+        - env: TOXENV='twine' TOX_ARGS=''
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        - os: linux
-          env: CMD="$SETUP_CMD build_docs -w"
+        - env: TOXENV='docbuild' TOX_ARGS=''
 
-        # Now try Astropy dev with the latest Python and LTS with Python 2.7 and 3.x.
+        # Do a code style check
+        - env: TOXENV='style' TOX_ARGS=''
+
+        # Try MacOS X and Windows
+        - os: osx
+          env: TOXENV='py37'
+
+        - os: windows
+          env: TOXENV='py37'
+
         - os: linux
-          env: ASTROPY_VERSION=development
+          env: TOXENV='py37-astrodev'
+               EVENT_TYPE='pull_request push cron'
+
+        - os: linux
+          env: TOXENV='py37-numpydev'
                EVENT_TYPE='pull_request push cron'
 
         # Test with glue installed
         - os: linux
-          env: PIP_DEPENDENCIES='pyqt5 pyqtgraph qtawesome qtpy click specutils>=0.5.2 sphinx-astropy pytest-astropy pytest-qt glue-core'
+          env: TOXENV='py37-glue'
 
-        # Test with latest stable versions of dependencies
-        - os: linux
-
-        # Try numpy pre-release
-        - os: linux
-          env: NUMPY_VERSION=prerelease
+    allow_failures:
+        - env: TOXENV='py37-astrodev'
                EVENT_TYPE='pull_request push cron'
-
-        # Do a PEP8 test with pycodestyle
-        - os: linux
-          env: CMD='pycodestyle specviz --count'
-               PIP_DEPENDENCIES='pycodestyle'
-
-        # Do a separate flake8 test for missing docstrings
-        - os: linux
-          env: CMD='flake8 --config=flake8docs.cfg --count specviz'
-               PIP_DEPENDENCIES='flake8 flake8-docstrings'
+        - env: TOXENV='py37-numpydev'
+               EVENT_TYPE='pull_request push cron'
 
 install:
 
-    # We now use the ci-helpers package to set up our testing environment.
-    # This is done by using Miniconda and then using conda and pip to install
-    # dependencies. Which dependencies are installed using conda and pip is
-    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
-    # which should be space-delimited lists of package names. See the README
-    # in https://github.com/astropy/ci-helpers for information about the full
-    # list of environment variables that can be used to customize your
-    # environment. In some cases, ci-helpers may not offer enough flexibility
-    # in how to install a package, in which case you can have additional
-    # commands in the install: section below.
-
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-
-    # As described above, using ci-helpers, you should be able to set up an
-    # environment with dependencies installed using conda and pip, but in some
-    # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python
-    # dependencies). Therefore, you can also include commands below (as
-    # well as at the start of the install section or in the before_install
-    # section if they are needed before setting up conda) to install any
-    # other dependencies.
+    - pip install tox tox-conda
 
 script:
-  # We do two separate test runs: one runs the main test suite where all tests
-  # share the same specviz application instance. The second runs only the JWST
-  # data loader tests, which each run in a separate subprocess.  These two
-  # different test cases do not play nicely when they run in the same pytest
-  # process, which is the reason for separating them here.
-  - if [[ $CMD == test ]]; then
-      pip install -e .;
-      pytest && JWST_DATA_TEST=1 pytest $DATA_TEST_PATH;
-    else
-      $CMD;
-    fi
-
-after_success:
-    # If coveralls.io is set up for this package, uncomment the line below.
-    # The coveragerc file may be customized as needed for your package.
-    # - if [[ $CMD == *coverage* ]]; then coveralls --rcfile='specviz/tests/coveragerc'; fi
+    - conda info
+    - $TOX_CMD $TOX_ARGS

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,8 @@
+[tox]
+envlist=
+    {py36,py37}-test
+    {py36,py37}-{astrodev,numpydev,glue}-test
+
 [testenv]
 deps=
     pytest
@@ -14,10 +19,9 @@ conda_deps=
     matplotlib
     glue: glue-core
     astrodev,numpydev: cython
-passenv= DISPLAY
+passenv= DISPLAY JWST_DATA_TEST
 commands=
     pytest {posargs}
-    JWST_DATA_TEST=1 pytest specviz/tests/test_load_data.py {posargs}
 
 [testenv:egg_info]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,83 @@
+[testenv]
+deps=
+    pytest
+    pytest-qt
+    pytest-sugar
+    pytest-astropy
+    pytest-faulthandler
+    astrodev: git+git://github.com/astropy/astropy
+    numpydev: git+git://github.com/numpy/numpy
+# These are the minimum dependencies required in order to set up our conda
+# environment to enable the PyQt GUI
+conda_deps=
+    pyqt
+    matplotlib
+    glue: glue-core
+    astrodev,numpydev: cython
+passenv= DISPLAY
+commands=
+    pytest {posargs}
+    JWST_DATA_TEST=1 pytest specviz/tests/test_load_data.py {posargs}
+
+[testenv:egg_info]
+deps=
+conda_deps=
+commands=
+    python setup.py egg_info
+
+[testenv:twine]
+basepython= python3.7
+deps=
+    twine
+conda_deps=
+commands=
+    twine check {distdir}/*
+
+[testenv:docbuild]
+basepython= python3.7
+deps=
+    sphinx-astropy
+    sphinx_rtd_theme
+conda_deps=
+    sphinx
+    graphviz
+    matplotlib
+commands=
+    python setup.py build_docs -w
+
+[testenv:checkdocs]
+basepython= python3.7
+deps=
+    collective.checkdocs
+    pygments
+commands=
+    python setup.py checkdocs
+
+[testenv:style]
+basepython= python3.7
+deps=
+    flake8
+    flake8-docstrings
+commands=
+    flake8 --count specviz
+    flake8 --config=flake8docs.cfg --count specviz
+
+[testenv:coverage]
+basepython= python3.7
+deps=
+    pytest
+    pytest-qt
+    pytest-sugar
+    pytest-astropy
+    pytest-faulthandler
+conda_deps=
+    pyqt
+    matplotlib
+    coverage
+    coveralls
+commands=
+    coverage run --source=specviz --rcfile={toxinidir}/specviz/tests/coveragerc \
+                 -m pytest --remote-data
+    coverage report -m
+    coveralls --rcfile={toxinidir}/specviz/tests/coveragerc
+passenv= TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH DISPLAY

--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ deps=
     flake8
     flake8-docstrings
 commands=
-    flake8 --count specviz
+    pycodestyle --count specviz
     flake8 --config=flake8docs.cfg --count specviz
 
 [testenv:coverage]


### PR DESCRIPTION
The motivation for this is that it allows for push-button replication of CI test environments locally. In order to run the tests using `tox` locally, it is necessary to have a `conda` environment with both `tox` and the `tox-conda` plugin installed (which are both currently only available from `pypi`).