### PR TITLE
Pin dependency versions to maintain compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ edit_on_github = True
 github_project = spacetelescope/specviz
 # install_requires should be formatted as a comma-separated list, e.g.:
 # install_requires = astropy, scipy, matplotlib
-install_requires = astropy>=3.1, pyqt5, pyqtgraph, qtawesome, qtpy, specutils>=0.5.2, click, pytest, asteval
+install_requires = astropy<4.0, pyqt5, pyqtgraph, qtawesome, qtpy, specutils<0.7, click, pytest, asteval
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.7.0.dev0
 # Note: you will also need to change this in your package's __init__.py


### PR DESCRIPTION
We have not update the qt version of specviz to be compatible with the latest astropy. This PR pins the versions to the current realm of tested dependencies.